### PR TITLE
Allow redirect to macOS install cURL

### DIFF
--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -60,7 +60,7 @@ On macOS:
 [source,bash]
 [subs="+attributes"]
 ----
-curl {uri-pkl-gen-swift-macos} -o pkl-gen-swift
+curl -L {uri-pkl-gen-swift-macos} -o pkl-gen-swift
 
 chmod +x pkl-gen-swift
 ----


### PR DESCRIPTION
cURL in the docs was not working due to not allowing redirect.

Added `-L` to allow redirects.