### PR TITLE
Fix license header

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -463,3 +463,13 @@ Apache 2.0 - https://github.com/apple/swift-system/blob/main/LICENSE.txt
     portions of this Software are embedded into the binary product as a result,
     you may redistribute such product without providing attribution as would
     otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+---
+
+This product contains a derivation of the lock implementation and various
+scripts from SwiftNIO.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio

--- a/Sources/PklSwift/locks.swift
+++ b/Sources/PklSwift/locks.swift
@@ -16,13 +16,13 @@
 
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwiftPkl open source project
+// This source file is part of the SwiftNIO open source project
 //
-// Copyright (c) 2017-2022 Apple Inc. and the SwiftPkl project authors
+// Copyright (c) 2017-2018 Apple Inc. and the SwiftNIO project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of SwiftPkl project authors
+// See CONTRIBUTORS.txt for the list of SwiftNIO project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
This fixes the license header on locks.swift and
adds appropriate attribution.