### PR TITLE
Fix module name

### DIFF
--- a/codegen/src/internal/TypeAliasGen.pkl
+++ b/codegen/src/internal/TypeAliasGen.pkl
@@ -1,3 +1,21 @@
+// ===----------------------------------------------------------------------===//
+// Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ===----------------------------------------------------------------------===//
+@Unlisted
+module pkl.swift.internal.TypeAliasGen
+
 extends "Gen.pkl"
 
 import "typegen.pkl"


### PR DESCRIPTION
This adds one more fix: there is a straggler module that was missing a name and a license header