### PR TITLE
Use `static loadFrom(source:)` in the quickstart

### DIFF
--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -106,7 +106,7 @@ Once defined, evaluate the Pkl module into Swift data.
 [source,swift]
 ----
 func main() async throws {
-	let config = try await AppConfig.loadFromPath("pkl/local/appConfig.pkl")
+	let config = try await AppConfig.loadFrom(source: .path("pkl/local/appConfig.pkl"))
 	print("I'm running on host \(config.host)\n")
 }
 ----


### PR DESCRIPTION
I found a non-existent API being used in the Quickstart document.