### PR TITLE
Remove iOS from supported platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,7 @@ let package = Package(
     name: "pkl-swift",
     platforms: [
         // required because of `Duration` API
-        .macOS(.v13),
-        .iOS(.v13),
+        .macOS(.v13)
     ],
     products: [
         .library(


### PR DESCRIPTION
## Summary

The package currently does not support iOS since it relies on `NSTask.Process` but iOS was included in the supported platforms in Package.swift.

## Changes

Remove iOS from the supported platform