### PR TITLE
Fix temporary directory creation to avoid failing pkl-core tests

### DIFF
--- a/Sources/PklSwift/Utils.swift
+++ b/Sources/PklSwift/Utils.swift
@@ -85,3 +85,12 @@ public func resolvePaths(_ paths: String...) -> String {
 }
 
 public let absoluteUriRegex = try! Regex("\\w+:")
+
+public func tempDir() throws -> URL {
+    (try FileManager.default.url(for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: URL(fileURLWithPath: "/"), create: true))
+}
+
+public func tempFile(suffix: String) throws -> URL {
+    let fileName = ProcessInfo.processInfo.globallyUniqueString + suffix
+    return (try tempDir()).appendingPathComponent(fileName)
+}

--- a/Sources/pkl-gen-swift/PklGenSwift.swift
+++ b/Sources/pkl-gen-swift/PklGenSwift.swift
@@ -77,11 +77,6 @@ struct PklGenSwift: AsyncParsableCommand {
     )
     var pklInputModules: [String] = []
 
-    func tempFile() -> URL {
-        let fileName = ProcessInfo.processInfo.globallyUniqueString + ".pkl"
-        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
-    }
-
     private func generateScriptUrl() -> String {
         if let generateScript = self.generateScript {
             return URL(fileURLWithPath: generateScript).path

--- a/Sources/pkl-gen-swift/PklSwiftGenerator.swift
+++ b/Sources/pkl-gen-swift/PklSwiftGenerator.swift
@@ -41,11 +41,6 @@ public struct PklSwiftGenerator {
         }
     }
 
-    private func tempFile() -> URL {
-        let fileName = ProcessInfo.processInfo.globallyUniqueString + ".pkl"
-        return URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
-    }
-
     private mutating func runModule(evaluator: Evaluator, pklInputModule: String) async throws {
         let out = resolvePaths(self.settings.outputPath ?? ".out")
         let moduleToEvaluate = """
@@ -55,7 +50,7 @@ public struct PklSwiftGenerator {
 
         moduleToGenerate = theModule
         """
-        let tempFile = tempFile()
+        let tempFile = try tempFile(suffix: ".pkl")
         try moduleToEvaluate.write(to: tempFile, atomically: true, encoding: .utf8)
         let files = try await evaluator.evaluateOutputFiles(source: .url(tempFile))
         for (filename, contents) in files {

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -308,7 +308,7 @@ final class PklSwiftTests: XCTestCase {
 // TODO re-enable this test when packages are available
 //
 //    func testWithProject() async throws {
-//        let project1Dir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("project1")
+//        let project1Dir = (try tempDir()).appendingPathComponent("project1")
 //        try FileManager.default.createDirectory(at: project1Dir, withIntermediateDirectories: true)
 //        try """
 //        amends "pkl:Project"

--- a/Tests/PklSwiftTests/ProjectTest.swift
+++ b/Tests/PklSwiftTests/ProjectTest.swift
@@ -22,10 +22,10 @@ import XCTest
 class ProjectTest: XCTestCase {
     func testLoadProject() async throws {
         let version = try await SemanticVersion(EvaluatorManager().getVersion())!
-        let tempDir = NSTemporaryDirectory()
-        try FileManager.default.createDirectory(atPath: tempDir + "/subdir", withIntermediateDirectories: true)
-        let otherProjectFile = URL(fileURLWithPath: tempDir, isDirectory: true)
-            .appendingPathComponent("subdir/PklProject")
+        let tempDir = try tempDir()
+        let subDir = tempDir.appendingPathComponent("subdir")
+        try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+        let otherProjectFile = subDir.appendingPathComponent("PklProject")
 
         try #"""
         amends "pkl:Project"
@@ -38,8 +38,8 @@ class ProjectTest: XCTestCase {
         }
         """#.write(to: otherProjectFile, atomically: true, encoding: .utf8)
 
-        let file = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent("PklProject")
+        let file = (try PklSwift.tempDir()).appendingPathComponent("PklProject")
+
         let httpSetting = version < pklVersion0_26 ? "" : """
         http {
           proxy {


### PR DESCRIPTION
Before this change, pkl-swift's tests (and pkl-gen-swift) write to the root of the user's temporary directory. This causes problems for some tests in pkl-core that rely on not finding a PklProject in any parent directory.