### PR TITLE
Make PathElement initializer explicitly public

### DIFF
--- a/Sources/PklSwift/Reader.swift
+++ b/Sources/PklSwift/Reader.swift
@@ -107,6 +107,11 @@ public struct PathElement {
 
     /// Whether the element is a directory or not.
     public let isDirectory: Bool
+
+    public init(name: String, isDirectory: Bool) {
+        self.name = name
+        self.isDirectory = isDirectory
+    }
 }
 
 extension PathElement {

--- a/Sources/PklSwift/Reader.swift
+++ b/Sources/PklSwift/Reader.swift
@@ -35,8 +35,8 @@ public protocol BaseReader {
     /// birds:catalog/swallow.pkl
     /// ```
     ///
-    /// The first URI conveys name "fred.pkl" within parent "/persons/". The second URI
-    /// conveys the name "persons/fred.pkl" with no hierarchical meaning.
+    /// The first URI conveys name "swallow.pkl" within parent "/catalog/". The second URI
+    /// conveys the name "catalog/swallow.pkl" with no hierarchical meaning.
     var hasHierarchicalUris: Bool { get }
 
     /// Returns elements at a specified path.


### PR DESCRIPTION
The type `PathElement` is part of the public `BaseReader` protocol and needs to be created by custom reader implementations. `PathElement` is used in the protocol `BaseReader` when the reader implements a hierarchical URI. This type however doesn't have at the moment a public initializer (Swift's compiler synthesizes an `internal` init for structs)