### PR TITLE
Fix enum decoding

### DIFF
--- a/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
@@ -15,7 +15,7 @@ extension UnionTypes {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as Banana:
                 self = Fruit.banana(decoded)
             case let decoded as Grape:
@@ -47,7 +47,7 @@ extension UnionTypes {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as Zebra:
                 self = ZebraOrDonkey.zebra(decoded)
             case let decoded as Donkey:
@@ -81,7 +81,7 @@ extension UnionTypes {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as any Animal:
                 self = AnimalOrString.animal(decoded)
             case let decoded as String:
@@ -103,6 +103,29 @@ extension UnionTypes {
                 hasher.combine(value)
             case let .string(value):
                 hasher.combine(value)
+            }
+        }
+    }
+
+    public enum IntOrFloat: Decodable, Hashable {
+        case int(Int)
+        case float64(Float64)
+
+        public init(from decoder: Decoder) throws {
+            let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
+            switch decoded?.base {
+            case let decoded as Int:
+                self = IntOrFloat.int(decoded)
+            case let decoded as Float64:
+                self = IntOrFloat.float64(decoded)
+            default:
+                throw DecodingError.typeMismatch(
+                    IntOrFloat.self,
+                    .init(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Expected type IntOrFloat, but got \(String(describing: decoded))"
+                    )
+                )
             }
         }
     }
@@ -132,6 +155,12 @@ extension UnionTypes {
 
         public var animalOrString2: AnimalOrString
 
+        public var intOrFloat1: IntOrFloat
+
+        public var intOrFloat2: IntOrFloat
+
+        public var intOrFloat3: IntOrFloat
+
         public init(
             fruit1: Fruit,
             fruit2: Fruit,
@@ -143,7 +172,10 @@ extension UnionTypes {
             animal1: ZebraOrDonkey,
             animal2: ZebraOrDonkey,
             animalOrString1: AnimalOrString,
-            animalOrString2: AnimalOrString
+            animalOrString2: AnimalOrString,
+            intOrFloat1: IntOrFloat,
+            intOrFloat2: IntOrFloat,
+            intOrFloat3: IntOrFloat
         ) {
             self.fruit1 = fruit1
             self.fruit2 = fruit2
@@ -156,6 +188,9 @@ extension UnionTypes {
             self.animal2 = animal2
             self.animalOrString1 = animalOrString1
             self.animalOrString2 = animalOrString2
+            self.intOrFloat1 = intOrFloat1
+            self.intOrFloat2 = intOrFloat2
+            self.intOrFloat3 = intOrFloat3
         }
     }
 

--- a/Tests/PklSwiftTests/Fixtures/UnionTypes.pkl
+++ b/Tests/PklSwiftTests/Fixtures/UnionTypes.pkl
@@ -53,3 +53,11 @@ typealias AnimalOrString = Animal|String
 animalOrString1: AnimalOrString = new Zebra {}
 
 animalOrString2: AnimalOrString = "Zebra"
+
+typealias IntOrFloat = Int | Float
+
+intOrFloat1: IntOrFloat = 5.0
+
+intOrFloat2: IntOrFloat = 5.5
+
+intOrFloat3: IntOrFloat = 5

--- a/Tests/PklSwiftTests/FixturesTest.swift
+++ b/Tests/PklSwiftTests/FixturesTest.swift
@@ -160,7 +160,10 @@ class FixturesTest: XCTestCase {
             animal1: .zebra(UnionTypes.Zebra(name: "Zebra")),
             animal2: .donkey(UnionTypes.Donkey(name: "Donkey")),
             animalOrString1: .animal(UnionTypes.Zebra(name: "Zebra")),
-            animalOrString2: .string("Zebra")
+            animalOrString2: .string("Zebra"),
+            intOrFloat1: .float64(5.0),
+            intOrFloat2: .float64(5.5),
+            intOrFloat3: .int(5)
         ))
     }
 }

--- a/codegen/snippet-tests/output/Enums.pkl.swift
+++ b/codegen/snippet-tests/output/Enums.pkl.swift
@@ -20,7 +20,7 @@ extension Enums {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as Horse:
                 self = Animal.horse(decoded)
             case let decoded as Zebra:
@@ -46,7 +46,7 @@ extension Enums {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as [String: String]:
                 self = DictOrArray.dictionaryStringString(decoded)
             case let decoded as [String]:
@@ -70,7 +70,7 @@ extension Enums {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as Horse:
                 self = HorseOrBug.horse(decoded)
             case let decoded as String:
@@ -95,7 +95,7 @@ extension Enums {
 
         public init(from decoder: Decoder) throws {
             let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value
-            switch decoded {
+            switch decoded?.base {
             case let decoded as Horse?:
                 self = MaybeHorseOrDefinitelyZebra.horse(decoded)
             case let decoded as Zebra:

--- a/codegen/src/internal/EnumGen.pkl
+++ b/codegen/src/internal/EnumGen.pkl
@@ -89,7 +89,7 @@ local enumContents =
     }
     "\(module.indent)public init(from decoder: Decoder) throws {"
     "\(module.indent.repeat(2))let decoded = try decoder.singleValueContainer().decode(PklSwift.PklAny.self).value"
-    "\(module.indent.repeat(2))switch decoded {"
+    "\(module.indent.repeat(2))switch decoded?.base {"
     for (member in enumNormalMembers) {
       "\(module.indent.repeat(2))case let decoded as \(member.renderedType):"
       "\(module.indent.repeat(3))self = \(module.mapping.name).\(member.name)(decoded)"


### PR DESCRIPTION
Fixes an issue where `5.0` in Pkl can possibly be cast to `Int`

Closes https://github.com/apple/pkl-swift/issues/36