### PR TITLE
Make enums of string literals conform to CodingKeyRepresentable

### DIFF
--- a/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
@@ -34,7 +34,7 @@ extension UnionTypes {
         }
     }
 
-    public enum City: String, CaseIterable, Decodable, Hashable {
+    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case sanFrancisco = "San Francisco"
         case tokyo = "Tokyo"
         case zurich = "Zurich"
@@ -130,6 +130,12 @@ extension UnionTypes {
         }
     }
 
+    public enum Environment: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+        case dev = "dev"
+        case prod = "prod"
+        case qa = "qa"
+    }
+
     public struct Module: PklRegisteredType, Decodable, Hashable {
         public static let registeredIdentifier: String = "UnionTypes"
 
@@ -161,6 +167,8 @@ extension UnionTypes {
 
         public var intOrFloat3: IntOrFloat
 
+        public var config: [Environment: String]
+
         public init(
             fruit1: Fruit,
             fruit2: Fruit,
@@ -175,7 +183,8 @@ extension UnionTypes {
             animalOrString2: AnimalOrString,
             intOrFloat1: IntOrFloat,
             intOrFloat2: IntOrFloat,
-            intOrFloat3: IntOrFloat
+            intOrFloat3: IntOrFloat,
+            config: [Environment: String]
         ) {
             self.fruit1 = fruit1
             self.fruit2 = fruit2
@@ -191,6 +200,7 @@ extension UnionTypes {
             self.intOrFloat1 = intOrFloat1
             self.intOrFloat2 = intOrFloat2
             self.intOrFloat3 = intOrFloat3
+            self.config = config
         }
     }
 

--- a/Tests/PklSwiftTests/Fixtures/UnionTypes.pkl
+++ b/Tests/PklSwiftTests/Fixtures/UnionTypes.pkl
@@ -61,3 +61,9 @@ intOrFloat1: IntOrFloat = 5.0
 intOrFloat2: IntOrFloat = 5.5
 
 intOrFloat3: IntOrFloat = 5
+
+typealias Environment = "dev"|"prod"|"qa"
+
+config: Mapping<Environment, String> = new {
+  ["dev"] = "Imaginary Service Company (ISC) configuration"
+}

--- a/Tests/PklSwiftTests/FixturesTest.swift
+++ b/Tests/PklSwiftTests/FixturesTest.swift
@@ -163,7 +163,8 @@ class FixturesTest: XCTestCase {
             animalOrString2: .string("Zebra"),
             intOrFloat1: .float64(5.0),
             intOrFloat2: .float64(5.5),
-            intOrFloat3: .int(5)
+            intOrFloat3: .int(5),
+            config: [.dev : "Imaginary Service Company (ISC) configuration"]
         ))
     }
 }

--- a/codegen/snippet-tests/output/Enums.pkl.swift
+++ b/codegen/snippet-tests/output/Enums.pkl.swift
@@ -5,7 +5,7 @@ public enum Enums {}
 
 extension Enums {
     /// City is one of these four fantastic cities
-    public enum City: String, CaseIterable, Decodable, Hashable {
+    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case sanFrancisco = "San Francisco"
         case london = "London"
         case zurich = "Zurich"

--- a/codegen/snippet-tests/output/ExplicitlyCoolName.pkl.swift
+++ b/codegen/snippet-tests/output/ExplicitlyCoolName.pkl.swift
@@ -4,7 +4,7 @@ import PklSwift
 public enum ExplicitlyCoolName {}
 
 extension ExplicitlyCoolName {
-    public enum ConfigType: String, CaseIterable, Decodable, Hashable {
+    public enum ConfigType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case one = "one"
         case two = "two"
     }

--- a/codegen/snippet-tests/output/UnionNameKeyword.pkl.swift
+++ b/codegen/snippet-tests/output/UnionNameKeyword.pkl.swift
@@ -4,7 +4,7 @@ import PklSwift
 public enum UnionNameKeyword {}
 
 extension UnionNameKeyword {
-    public enum `Type`: String, CaseIterable, Decodable, Hashable {
+    public enum `Type`: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case one = "one"
         case two = "two"
         case three = "three"

--- a/codegen/snippet-tests/output/union.pkl.swift
+++ b/codegen/snippet-tests/output/union.pkl.swift
@@ -5,28 +5,28 @@ public enum union {}
 
 extension union {
     /// City; e.g. where people live
-    public enum City: String, CaseIterable, Decodable, Hashable {
+    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case sanFrancisco = "San Francisco"
         case london = "London"
         case 上海 = "上海"
     }
 
     /// Locale that contains cities and towns
-    public enum County: String, CaseIterable, Decodable, Hashable {
+    public enum County: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case sanFrancisco = "San Francisco"
         case sanMateo = "San Mateo"
         case yolo = "Yolo"
     }
 
     /// Noodles
-    public enum Noodles: String, CaseIterable, Decodable, Hashable {
+    public enum Noodles: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case 拉面 = "拉面"
         case 刀切面 = "刀切面"
         case 面线 = "面线"
         case 意大利面 = "意大利面"
     }
 
-    public enum AccountDisposition: String, CaseIterable, Decodable, Hashable {
+    public enum AccountDisposition: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
         case empty = ""
         case icloud3 = "icloud3"
         case prod = "prod"

--- a/codegen/src/internal/EnumGen.pkl
+++ b/codegen/src/internal/EnumGen.pkl
@@ -67,7 +67,7 @@ local stringLiteralEnumContents =
     when (alias.docComment != null) {
       utils.renderDocComment(alias.docComment!!, "")
     }
-    "public enum \(module.mapping.name): String, CaseIterable, Decodable, Hashable {"
+    "public enum \(module.mapping.name): String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {"
     for (member in enumStringLiteralMembers) {
       "\(module.indent)case \(member.name) = \(utils.toSwiftString((member.pklType as reflect.StringLiteralType).value))"
     }


### PR DESCRIPTION
Fixes an issue where mappings of enums fail to be decoded into Swift

Fixes #44 