### PR TITLE
Swift 6 preparations

### DIFF
--- a/Sources/PklSwift/API/Duration.swift
+++ b/Sources/PklSwift/API/Duration.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// Duration is the Swift representation of Pkl's `pkl.Duration`.
-public struct Duration: Hashable {
+public struct Duration: Hashable, Sendable {
     /// The value of this ``Duration`` in the unit set in ``unit``.
     public let value: Float64
 
@@ -137,7 +137,7 @@ extension Duration {
 }
 
 /// A unit (magnitude) of duration.
-public enum DurationUnit: String, CaseIterable, Decodable {
+public enum DurationUnit: String, CaseIterable, Decodable, Sendable {
     /// Nanosecond
     case ns
 

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -29,12 +29,16 @@ let PKL_EXEC_NAME="pkl"
 /// Perfoms `action`, returns its result and then closes the manager.
 ///
 /// - Parameter action: The action to perform
+/// - Parameter isolation: Run under the given actor isolation.  Defaults to surrounding actor
 /// - Returns: The result of `action`
-public func withEvaluatorManager<T>(_ action: (EvaluatorManager) async throws -> T) async rethrows -> T {
-    let manager: EvaluatorManager = .init()
+public func withEvaluatorManager<T: Sendable>(
+    isolation: isolated (any Actor)? = #isolation,
+    _ action: (inout sending EvaluatorManager) async throws -> T
+) async rethrows -> T {
+    var manager: EvaluatorManager = .init()
     var closed = false
     do {
-        let result = try await action(manager)
+        let result = try await action(&manager)
         await manager.close()
         closed = true
         return result

--- a/Sources/PklSwift/ModuleSource.swift
+++ b/Sources/PklSwift/ModuleSource.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 /// A representation of a source for a Pkl module to be evaluated.
-public struct ModuleSource: Hashable {
+public struct ModuleSource: Hashable, Sendable {
     /// The URI of the module.
     let uri: URL
 

--- a/Sources/PklSwift/PklEvaluatorSettings.swift
+++ b/Sources/PklSwift/PklEvaluatorSettings.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 /// The Swift representation of standard library module `pkl.EvaluatorSettings`.
-public struct PklEvaluatorSettings: Decodable, Hashable {
+public struct PklEvaluatorSettings: Decodable, Hashable, Sendable {
     let externalProperties: [String: String]?
     let env: [String: String]?
     let allowedModules: [String]?
@@ -51,7 +51,7 @@ public enum PklEvaluatorSettingsColor: String, CaseIterable, Decodable, Hashable
 }
 
 /// Settings that control how Pkl talks to HTTP(S) servers.
-public struct Http: Codable, Hashable {
+public struct Http: Codable, Hashable, Sendable {
     /// PEM format certificates to trust when making HTTP requests.
     ///
     /// If empty, Pkl will trust its own built-in certificates.
@@ -65,7 +65,7 @@ public struct Http: Codable, Hashable {
 }
 
 /// Settings that control how Pkl talks to HTTP proxies.
-public struct Proxy: Codable, Hashable {
+public struct Proxy: Codable, Hashable, Sendable {
     /// The proxy to use for HTTP(S) connections.
     ///
     /// Only HTTP proxies are supported.

--- a/Sources/PklSwift/PklEvaluatorSettings.swift
+++ b/Sources/PklSwift/PklEvaluatorSettings.swift
@@ -39,7 +39,7 @@ public struct PklEvaluatorSettings: Decodable, Hashable, Sendable {
     let color: PklEvaluatorSettingsColor?
 }
 
-public enum PklEvaluatorSettingsColor: String, CaseIterable, Decodable, Hashable {
+public enum PklEvaluatorSettingsColor: String, CaseIterable, Decodable, Hashable, Sendable {
     /// Never format.
     case never
 
@@ -108,7 +108,7 @@ public struct Proxy: Codable, Hashable, Sendable {
     var noProxy: [String]?
 }
 
-public struct ExternalReader: Codable, Hashable {
+public struct ExternalReader: Codable, Hashable, Sendable {
     var executable: String
     var arguments: [String]? = nil
 }

--- a/Sources/PklSwift/Reader.swift
+++ b/Sources/PklSwift/Reader.swift
@@ -101,7 +101,7 @@ extension ResourceReader {
 ///
 /// For example, a ``PathElement`` with name `bar.txt` and is not a directory at base URI `file:////foo/`
 /// implies URI resource `file:///foo/bar.txt`.
-public struct PathElement {
+public struct PathElement: Sendable {
     /// The name of the path element
     public let name: String
 

--- a/codegen/snippet-tests/output/Classes.pkl.swift
+++ b/codegen/snippet-tests/output/Classes.pkl.swift
@@ -1,14 +1,14 @@
 // Code generated from Pkl module `Classes`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum Classes {}
+public enum Classes: Sendable {}
 
-public protocol Classes_Animal: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol Classes_Animal: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var name: String { get }
 }
 
 extension Classes {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Classes"
 
         public var animals: [any Animal]

--- a/codegen/snippet-tests/output/EmptyOpenModule.pkl.swift
+++ b/codegen/snippet-tests/output/EmptyOpenModule.pkl.swift
@@ -1,9 +1,9 @@
 // Code generated from Pkl module `EmptyOpenModule`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum EmptyOpenModule {}
+public enum EmptyOpenModule: Sendable {}
 
-public protocol EmptyOpenModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol EmptyOpenModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
 }
 
 extension EmptyOpenModule {

--- a/codegen/snippet-tests/output/Enums.pkl.swift
+++ b/codegen/snippet-tests/output/Enums.pkl.swift
@@ -1,11 +1,11 @@
 // Code generated from Pkl module `Enums`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum Enums {}
+public enum Enums: Sendable {}
 
 extension Enums {
     /// City is one of these four fantastic cities
-    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case sanFrancisco = "San Francisco"
         case london = "London"
         case zurich = "Zurich"
@@ -13,7 +13,7 @@ extension Enums {
     }
 
     /// Animal is either a horse, monkey, or zebra
-    public enum Animal: Decodable, Hashable {
+    public enum Animal: Decodable, Hashable, Sendable {
         case horse(Horse)
         case zebra(Zebra)
         case monkey(Monkey)
@@ -41,7 +41,7 @@ extension Enums {
     }
 
     /// Either a dictionary or an array.
-    public enum DictOrArray: Decodable, Hashable {
+    public enum DictOrArray: Decodable, Hashable, Sendable {
         case dictionaryStringString([String: String])
         case arrayString([String])
 
@@ -65,7 +65,7 @@ extension Enums {
         }
     }
 
-    public enum HorseOrBug: Decodable, Hashable {
+    public enum HorseOrBug: Decodable, Hashable, Sendable {
         case horse(Horse)
         case string(String)
         case string(String)
@@ -92,7 +92,7 @@ extension Enums {
         }
     }
 
-    public enum MaybeHorseOrDefinitelyZebra: Decodable, Hashable {
+    public enum MaybeHorseOrDefinitelyZebra: Decodable, Hashable, Sendable {
         case horse(Horse?)
         case zebra(Zebra)
 
@@ -116,7 +116,7 @@ extension Enums {
         }
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Enums"
 
         /// City of tomorrow!
@@ -148,7 +148,7 @@ extension Enums {
         }
     }
 
-    public struct Horse: PklRegisteredType, Decodable, Hashable {
+    public struct Horse: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Enums#Horse"
 
         public var neigh: Bool
@@ -158,7 +158,7 @@ extension Enums {
         }
     }
 
-    public struct Zebra: PklRegisteredType, Decodable, Hashable {
+    public struct Zebra: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Enums#Zebra"
 
         public var stripes: String
@@ -168,7 +168,7 @@ extension Enums {
         }
     }
 
-    public struct Monkey: PklRegisteredType, Decodable, Hashable {
+    public struct Monkey: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Enums#Monkey"
 
         public var tail: String

--- a/codegen/snippet-tests/output/ExplicitlyCoolName.pkl.swift
+++ b/codegen/snippet-tests/output/ExplicitlyCoolName.pkl.swift
@@ -1,15 +1,15 @@
 // Code generated from Pkl module `ExplicitName`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum ExplicitlyCoolName {}
+public enum ExplicitlyCoolName: Sendable {}
 
 extension ExplicitlyCoolName {
-    public enum ConfigType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum ConfigType: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case one = "one"
         case two = "two"
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "ExplicitName"
 
         public var MyCoolProp: SomethingVeryFunny
@@ -23,7 +23,7 @@ extension ExplicitlyCoolName {
         }
     }
 
-    public struct SomethingVeryFunny: PklRegisteredType, Decodable, Hashable {
+    public struct SomethingVeryFunny: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "ExplicitName#SomethingFunny"
 
         public init() {}

--- a/codegen/snippet-tests/output/ExtendModule.pkl.swift
+++ b/codegen/snippet-tests/output/ExtendModule.pkl.swift
@@ -1,7 +1,7 @@
 // Code generated from Pkl module `ExtendModule`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum ExtendModule {}
+public enum ExtendModule: Sendable {}
 
 extension ExtendModule {
     public struct Module: MyModule.Module {

--- a/codegen/snippet-tests/output/ExtendingOpenClass.pkl.swift
+++ b/codegen/snippet-tests/output/ExtendingOpenClass.pkl.swift
@@ -1,14 +1,14 @@
 // Code generated from Pkl module `ExtendingOpenClass`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum ExtendingOpenClass {}
+public enum ExtendingOpenClass: Sendable {}
 
-public protocol ExtendingOpenClass_MyOpenClass: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol ExtendingOpenClass_MyOpenClass: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var myStr: String { get }
 }
 
 extension ExtendingOpenClass {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "ExtendingOpenClass"
 
         public var res1: MyClass

--- a/codegen/snippet-tests/output/ExtendsAbstractClass.pkl.swift
+++ b/codegen/snippet-tests/output/ExtendsAbstractClass.pkl.swift
@@ -1,14 +1,14 @@
 // Code generated from Pkl module `ExtendsAbstractClass`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum ExtendsAbstractClass {}
+public enum ExtendsAbstractClass: Sendable {}
 
-public protocol ExtendsAbstractClass_A: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol ExtendsAbstractClass_A: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var b: String { get }
 }
 
 extension ExtendsAbstractClass {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "ExtendsAbstractClass"
 
         public var a: any A

--- a/codegen/snippet-tests/output/Foo.pkl.swift
+++ b/codegen/snippet-tests/output/Foo.pkl.swift
@@ -1,18 +1,18 @@
 // Code generated from Pkl module `Foo`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum Foo {}
+public enum Foo: Sendable {}
 
 public protocol Foo_Animal: Foo_Being {
     var name: String { get }
 }
 
-public protocol Foo_Being: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol Foo_Being: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var exists: Bool { get }
 }
 
 extension Foo {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Foo"
 
         public var animals: [any Animal]

--- a/codegen/snippet-tests/output/HiddenProperties.pkl.swift
+++ b/codegen/snippet-tests/output/HiddenProperties.pkl.swift
@@ -1,10 +1,10 @@
 // Code generated from Pkl module `HiddenProperties`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum HiddenProperties {}
+public enum HiddenProperties: Sendable {}
 
 extension HiddenProperties {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "HiddenProperties"
 
         public var propC: String

--- a/codegen/snippet-tests/output/Imports.pkl.swift
+++ b/codegen/snippet-tests/output/Imports.pkl.swift
@@ -1,10 +1,10 @@
 // Code generated from Pkl module `Imports`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum Imports {}
+public enum Imports: Sendable {}
 
 extension Imports {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "Imports"
 
         public var foo: Foo.Module

--- a/codegen/snippet-tests/output/MyModule.pkl.swift
+++ b/codegen/snippet-tests/output/MyModule.pkl.swift
@@ -1,9 +1,9 @@
 // Code generated from Pkl module `MyModule`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum MyModule {}
+public enum MyModule: Sendable {}
 
-public protocol MyModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol MyModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var foo: String { get }
 }
 

--- a/codegen/snippet-tests/output/Override2.pkl.swift
+++ b/codegen/snippet-tests/output/Override2.pkl.swift
@@ -1,9 +1,9 @@
 // Code generated from Pkl module `Override2`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum Override2 {}
+public enum Override2: Sendable {}
 
-public protocol Override2_Module: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol Override2_Module: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var foo: String { get }
 }
 

--- a/codegen/snippet-tests/output/TypeAliased.pkl.swift
+++ b/codegen/snippet-tests/output/TypeAliased.pkl.swift
@@ -1,10 +1,10 @@
 // Code generated from Pkl module `TypeAliased`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum TypeAliased {}
+public enum TypeAliased: Sendable {}
 
 extension TypeAliased {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "TypeAliased"
 
         public var myMap: StringyMap

--- a/codegen/snippet-tests/output/UnionNameKeyword.pkl.swift
+++ b/codegen/snippet-tests/output/UnionNameKeyword.pkl.swift
@@ -1,16 +1,16 @@
 // Code generated from Pkl module `UnionNameKeyword`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum UnionNameKeyword {}
+public enum UnionNameKeyword: Sendable {}
 
 extension UnionNameKeyword {
-    public enum `Type`: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum `Type`: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case one = "one"
         case two = "two"
         case three = "three"
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "UnionNameKeyword"
 
         public var type: `Type`

--- a/codegen/snippet-tests/output/com_example_ExtendedSimple.pkl.swift
+++ b/codegen/snippet-tests/output/com_example_ExtendedSimple.pkl.swift
@@ -1,10 +1,10 @@
 // Code generated from Pkl module `com.example.ExtendedSimple`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum com_example_ExtendedSimple {}
+public enum com_example_ExtendedSimple: Sendable {}
 
 extension com_example_ExtendedSimple {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "com.example.ExtendedSimple"
 
         public init() {}

--- a/codegen/snippet-tests/output/com_example_Simple.pkl.swift
+++ b/codegen/snippet-tests/output/com_example_Simple.pkl.swift
@@ -1,20 +1,20 @@
 // Code generated from Pkl module `com.example.Simple`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum com_example_Simple {}
+public enum com_example_Simple: Sendable {}
 
-public protocol com_example_Simple_Person: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol com_example_Simple_Person: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var theName: String { get }
 
     var `enum`: String { get }
 }
 
-public protocol com_example_Simple_OpenClassExtendingOpenClass: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol com_example_Simple_OpenClassExtendingOpenClass: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var someOtherProp: Bool? { get }
 }
 
 extension com_example_Simple {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "com.example.Simple"
 
         /// This is truly a person.
@@ -98,7 +98,7 @@ extension com_example_Simple {
         }
     }
 
-    public struct ClassWithReallyLongConstructor: PklRegisteredType, Decodable, Hashable {
+    public struct ClassWithReallyLongConstructor: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "com.example.Simple#ClassWithReallyLongConstructor"
 
         public var theProperty1: String

--- a/codegen/snippet-tests/output/lib3.pkl.swift
+++ b/codegen/snippet-tests/output/lib3.pkl.swift
@@ -1,9 +1,9 @@
 // Code generated from Pkl module `lib3`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum lib3 {}
+public enum lib3: Sendable {}
 
-public protocol lib3_GoGoGo: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol lib3_GoGoGo: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var duck: String { get }
 }
 
@@ -20,7 +20,7 @@ extension lib3 {
         }
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "lib3"
 
         public init() {}

--- a/codegen/snippet-tests/output/override.pkl.swift
+++ b/codegen/snippet-tests/output/override.pkl.swift
@@ -1,14 +1,14 @@
 // Code generated from Pkl module `override`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum override {}
+public enum override: Sendable {}
 
-public protocol override_Foo: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol override_Foo: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var myProp: String { get }
 }
 
 extension override {
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "override"
 
         public var foo: any Foo

--- a/codegen/snippet-tests/output/union.pkl.swift
+++ b/codegen/snippet-tests/output/union.pkl.swift
@@ -1,39 +1,39 @@
 // Code generated from Pkl module `union`. DO NOT EDIT.
-import PklSwift
+@preconcurrency import PklSwift
 
-public enum union {}
+public enum union: Sendable {}
 
 extension union {
     /// City; e.g. where people live
-    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum City: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case sanFrancisco = "San Francisco"
         case london = "London"
         case 上海 = "上海"
     }
 
     /// Locale that contains cities and towns
-    public enum County: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum County: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case sanFrancisco = "San Francisco"
         case sanMateo = "San Mateo"
         case yolo = "Yolo"
     }
 
     /// Noodles
-    public enum Noodles: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum Noodles: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case 拉面 = "拉面"
         case 刀切面 = "刀切面"
         case 面线 = "面线"
         case 意大利面 = "意大利面"
     }
 
-    public enum AccountDisposition: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {
+    public enum AccountDisposition: String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {
         case empty = ""
         case icloud3 = "icloud3"
         case prod = "prod"
         case shared = "shared"
     }
 
-    public struct Module: PklRegisteredType, Decodable, Hashable {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
         public static let registeredIdentifier: String = "union"
 
         /// A city

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -139,7 +139,7 @@ local structSuperclasses: String =
     else
       "\(superClass.namespaceName).\(superClass.name)"
   else
-    "PklRegisteredType, Decodable, Hashable"
+    "PklRegisteredType, Decodable, Hashable, Sendable"
 
 local struct: String = new Listing {
   when (clazz.docComment != null) {
@@ -338,7 +338,7 @@ local protocol: String? =
         when (superClass != null) {
           "\(superClass.protocol.fullName) {\n"
         } else {
-          "PklRegisteredType, DynamicallyEquatable, Hashable {\n"
+          "PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {\n"
         }
         for (key, field in methodsToGenerate) {
           when (key != methodsToGenerate.keys.first) {

--- a/codegen/src/internal/EnumGen.pkl
+++ b/codegen/src/internal/EnumGen.pkl
@@ -71,7 +71,7 @@ local stringLiteralEnumContents =
     when (alias.docComment != null) {
       utils.renderDocComment(alias.docComment!!, "")
     }
-    "public enum \(module.mapping.name): String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable {"
+    "public enum \(module.mapping.name): String, CaseIterable, CodingKeyRepresentable, Decodable, Hashable, Sendable {"
     for (member in enumStringLiteralMembers) {
       "\(module.indent)case \(member.name) = \(utils.toSwiftString((member.pklType as reflect.StringLiteralType).value))"
     }
@@ -83,7 +83,7 @@ local enumContents =
     when (alias.docComment != null) {
       utils.renderDocComment(alias.docComment!!, "")
     }
-    "public enum \(module.mapping.name): Decodable, Hashable {"
+    "public enum \(module.mapping.name): Decodable, Hashable, Sendable {"
     for (member: EnumMember in enumNormalMembers) {
       "\(module.indent)case \(member.name)(\(member.renderedType))"
     }

--- a/codegen/src/internal/SwiftNamespace.pkl
+++ b/codegen/src/internal/SwiftNamespace.pkl
@@ -124,7 +124,7 @@ contents = new Listing {
   """
   @preconcurrency import PklSwift
 
-  public enum \(namespaceName) {}
+  public enum \(namespaceName): Sendable {}
 
   """
   when (topLevelContents.length > 0) {

--- a/codegen/src/internal/SwiftNamespace.pkl
+++ b/codegen/src/internal/SwiftNamespace.pkl
@@ -122,7 +122,7 @@ local convenienceLoaders = """
 contents = new Listing {
   utils.renderHeaderComment(`module`)
   """
-  import PklSwift
+  @preconcurrency import PklSwift
 
   public enum \(namespaceName) {}
 


### PR DESCRIPTION
This PR adds actor isolation to `withEvaluatorManager` as done by other APIs like [AsyncHTTPClient](https://github.com/swift-server/async-http-client/blob/0397ea83926376bd2e2cecc196e450526b7e33b3/Sources/AsyncHTTPClient/HTTPClient%2BStructuredConcurrency.swift#L31). This is explained in detail in this [talk](https://www.youtube.com/watch?v=JmrnE7HUaDE), and is part of [SE-0461](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md) where it will be the default.

I noticed this when I tried to call this function from [the library I am working on](https://github.com/vault-courier/vault-courier/blob/main/Sources/VaultCourier/VaultReader/ModuleSourceReader.swift#L81). As the above SE proposal says, it's easy to miss:

> It's easy to write invalid async APIs. If the performAsync method were in a library that the programmer doesn't own, it's not possible to workaround the data-race safety error without using unsafe opt outs. It's common for library authors to mistakenly vend an API like this, because the data-race safety error only manifests when calling the API from an actor.

The PR also includes a change in the swift codegen types so that they are marked `Sendable`, and `PklSwift` is imported with `@preconcurrency`.

In addition, marked some basic types `Sendable`:

- `Duration`
- `DurationUnit`
- `ModuleSource`
- `PklEvaluatorSettings`
- `PklEvaluatorSettingsColor`
- `Http`
- `Proxy`
- `ExternalReader`, and
- `PathElement`