### PR TITLE
pkl-gen-swift: Add support for projects

### DIFF
--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -302,7 +302,7 @@ public actor EvaluatorManager {
         }
         return try await self.withEvaluator(options: .preconfigured) { projectEvaluator in
             let project = try await projectEvaluator.evaluateOutputValue(
-                source: .url(projectBaseURI.appending(component: "PklProject")),
+                source: .url(projectBaseURI.appendingPathComponent("PklProject")),
                 asType: Project.self
             )
             return try await self.newEvaluator(options: options.withProject(project))

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -302,7 +302,7 @@ public actor EvaluatorManager {
         }
         return try await self.withEvaluator(options: .preconfigured) { projectEvaluator in
             let project = try await projectEvaluator.evaluateOutputValue(
-                source: .path("\(projectBaseURI)/PklProject"),
+                source: .url(projectBaseURI.appending(component: "PklProject")),
                 asType: Project.self
             )
             return try await self.newEvaluator(options: options.withProject(project))

--- a/Sources/PklSwift/EvaluatorOptions.swift
+++ b/Sources/PklSwift/EvaluatorOptions.swift
@@ -191,7 +191,7 @@ extension EvaluatorOptions {
         return .init(
             packageUri: nil,
             type: "project",
-            projectFileUri: "\(projectBaseURI.appending(component: "PklProject"))",
+            projectFileUri: "\(projectBaseURI.appendingPathComponent("PklProject"))",
             checksums: nil,
             dependencies: self.declaredProjectDependenciesToMessage(self.declaredProjectDependencies)
         )

--- a/Sources/PklSwift/EvaluatorOptions.swift
+++ b/Sources/PklSwift/EvaluatorOptions.swift
@@ -191,7 +191,7 @@ extension EvaluatorOptions {
         return .init(
             packageUri: nil,
             type: "project",
-            projectFileUri: "file://\(projectBaseURI)/PklProject",
+            projectFileUri: "\(projectBaseURI.appending(component: "PklProject"))",
             checksums: nil,
             dependencies: self.declaredProjectDependenciesToMessage(self.declaredProjectDependencies)
         )

--- a/Sources/pkl-gen-swift/Generated/GeneratorSettings.pkl.swift
+++ b/Sources/pkl-gen-swift/Generated/GeneratorSettings.pkl.swift
@@ -4,55 +4,70 @@ import PklSwift
 public enum GeneratorSettings {}
 
 extension GeneratorSettings {
-  /// Settings used to configure code generation.
-  public struct Module: PklRegisteredType, Decodable, Hashable {
-    public static let registeredIdentifier: String = "pkl.swift.GeneratorSettings"
+    /// Settings used to configure code generation.
+    public struct Module: PklRegisteredType, Decodable, Hashable {
+        public static let registeredIdentifier: String = "pkl.swift.GeneratorSettings"
 
-    /// The set of modules to turn into Swift code.
-    ///
-    /// A module's dependencies are also included in code generation.
-    /// Therefore, in most cases, it is only necessary to provide the entrypoint for code generation.
-    public var inputs: [String]?
+        /// The set of modules to turn into Swift code.
+        ///
+        /// A module's dependencies are also included in code generation.
+        /// Therefore, in most cases, it is only necessary to provide the entrypoint for code generation.
+        public var inputs: [String]?
 
-    /// The output path to write generated files into.
-    ///
-    /// Defaults to `.out`. Relative paths are resolved against the enclosing directory.
-    public var outputPath: String?
+        /// The output path to write generated files into.
+        ///
+        /// Defaults to `.out`. Relative paths are resolved against the enclosing directory.
+        public var outputPath: String?
 
-    /// If [true], prints the filenames that would be created, but skips writing any files.
-    public var dryRun: Bool?
+        /// If [true], prints the filenames that would be created, but skips writing any files.
+        public var dryRun: Bool?
 
-    /// The Generator.pkl script to use for code generation.
-    ///
-    /// This is an internal setting that's meant for development purposes.
-    public var generateScript: String?
+        /// The Generator.pkl script to use for code generation.
+        ///
+        /// This is an internal setting that's meant for development purposes.
+        public var generateScript: String?
 
-    public init(inputs: [String]?, outputPath: String?, dryRun: Bool?, generateScript: String?) {
-      self.inputs = inputs
-      self.outputPath = outputPath
-      self.dryRun = dryRun
-      self.generateScript = generateScript
+        /// The project directory to control dependency and evaluator settings during codegen.
+        ///
+        /// This corresponds to the `--project-dir` flag in the Pkl CLI.
+        /// Relative paths are resolved against the enclosing directory.
+        ///
+        /// Paths must use `/` as the path separator.
+        public var projectDir: String?
+
+        public init(
+            inputs: [String]?,
+            outputPath: String?,
+            dryRun: Bool?,
+            generateScript: String?,
+            projectDir: String?
+        ) {
+            self.inputs = inputs
+            self.outputPath = outputPath
+            self.dryRun = dryRun
+            self.generateScript = generateScript
+            self.projectDir = projectDir
+        }
     }
-  }
 
-  /// Load the Pkl module at the given source and evaluate it into `GeneratorSettings.Module`.
-  ///
-  /// - Parameter source: The source of the Pkl module.
-  public static func loadFrom(source: ModuleSource) async throws -> GeneratorSettings.Module {
-    try await PklSwift.withEvaluator { evaluator in
-      try await loadFrom(evaluator: evaluator, source: source)
+    /// Load the Pkl module at the given source and evaluate it into `GeneratorSettings.Module`.
+    ///
+    /// - Parameter source: The source of the Pkl module.
+    public static func loadFrom(source: ModuleSource) async throws -> GeneratorSettings.Module {
+        try await PklSwift.withEvaluator { evaluator in
+            try await loadFrom(evaluator: evaluator, source: source)
+        }
     }
-  }
 
-  /// Load the Pkl module at the given source and evaluates it with the given evaluator into
-  /// `GeneratorSettings.Module`.
-  ///
-  /// - Parameter evaluator: The evaluator to use for evaluation.
-  /// - Parameter source: The module to evaluate.
-  public static func loadFrom(
-    evaluator: PklSwift.Evaluator,
-    source: PklSwift.ModuleSource
-  ) async throws -> GeneratorSettings.Module {
-    try await evaluator.evaluateModule(source: source, as: Module.self)
-  }
+    /// Load the Pkl module at the given source and evaluate it with the given evaluator into
+    /// `GeneratorSettings.Module`.
+    ///
+    /// - Parameter evaluator: The evaluator to use for evaluation.
+    /// - Parameter source: The module to evaluate.
+    public static func loadFrom(
+        evaluator: PklSwift.Evaluator,
+        source: PklSwift.ModuleSource
+    ) async throws -> GeneratorSettings.Module {
+        try await evaluator.evaluateModule(source: source, as: Module.self)
+    }
 }

--- a/Sources/pkl-gen-swift/PklGenSwift.swift
+++ b/Sources/pkl-gen-swift/PklGenSwift.swift
@@ -17,7 +17,7 @@
 import ArgumentParser
 import Foundation
 import PklSwift
-import System
+import SystemPackage
 
 let VERSION = String(decoding: Data(PackageResources.VERSION_txt), as: UTF8.self)
 
@@ -136,7 +136,8 @@ struct PklGenSwift: AsyncParsableCommand {
             )
         }
         if let projectDir = self.findProjectDir(projectDirFlag: self.projectDir) {
-            return try await withProjectEvaluator(projectBaseURI: .init(filePath: projectDir)!, options: options, doEval)
+            let path = "\(projectDir)"
+            return try await withProjectEvaluator(projectBaseURI: .init(fileURLWithPath: path, isDirectory: true), options: options, doEval)
         } else {
             return try await withEvaluator(options: options, doEval)
         }
@@ -155,7 +156,11 @@ struct PklGenSwift: AsyncParsableCommand {
         }
         generatorSettings.generateScript = self.generateScriptUrl()
         if let projectDir = self.projectDir {
+            // if explicitly set as a CLI flag, use it directly
             generatorSettings.projectDir = projectDir
+        } else if generatorSettings.projectDir == nil, let projectDir = self.findProjectDir(projectDirFlag: nil) {
+            // otherwise if not set in generator-settings file, detect it from CWD.
+            generatorSettings.projectDir = "\(projectDir)"
         }
         return generatorSettings
     }

--- a/Sources/pkl-gen-swift/PklGenSwift.swift
+++ b/Sources/pkl-gen-swift/PklGenSwift.swift
@@ -129,14 +129,13 @@ struct PklGenSwift: AsyncParsableCommand {
         }
         var options = EvaluatorOptions.preconfigured
         options.logger = Loggers.standardError
-        let projectDir = self.findProjectDir(projectDirFlag: self.projectDir)
         let doEval: (Evaluator) async throws -> GeneratorSettings.Module = { evaluator in
             try await evaluator.evaluateOutputValue(
                 source: .path(settingsFile),
                 asType: GeneratorSettings.Module.self
             )
         }
-        if let projectDir {
+        if let projectDir = self.findProjectDir(projectDirFlag: self.projectDir) {
             return try await withProjectEvaluator(projectBaseURI: .init(filePath: projectDir)!, options: options, doEval)
         } else {
             return try await withEvaluator(options: options, doEval)

--- a/Sources/pkl-gen-swift/PklSwiftGenerator.swift
+++ b/Sources/pkl-gen-swift/PklSwiftGenerator.swift
@@ -31,13 +31,18 @@ public struct PklSwiftGenerator {
     public mutating func run() async throws {
         var options = EvaluatorOptions.preconfigured
         options.logger = Loggers.standardError
-        try await withEvaluator(options: options) { evaluator in
+        let doEval: (Evaluator) async throws -> Void = { evaluator in
             for pklInputModule in self.settings.inputs ?? [] {
                 try await self.runModule(
                     evaluator: evaluator,
                     pklInputModule: pklInputModule
                 )
             }
+        }
+        if let projectDir = settings.projectDir {
+            return try await withProjectEvaluator(projectBaseURI: URL(fileURLWithPath: projectDir), options: options, doEval)
+        } else {
+            return try await withEvaluator(options: options, doEval)
         }
     }
 

--- a/codegen/src/GeneratorSettings.pkl
+++ b/codegen/src/GeneratorSettings.pkl
@@ -41,6 +41,14 @@ dryRun: Boolean?
 /// This is an internal setting that's meant for development purposes.
 generateScript: String?
 
+/// The project directory to control dependency and evaluator settings during codegen.
+///
+/// This corresponds to the `--project-dir` flag in the Pkl CLI.
+/// Relative paths are resolved against the enclosing directory.
+///
+/// Paths must use `/` as the path separator.
+projectDir: String?
+
 output {
   local myModuleDirectory =
     let (myModuleUri = reflect.Module(module).uri)
@@ -60,6 +68,9 @@ output {
     }
     when (module.outputPath != null) {
       outputPath = resolvePath(module.outputPath!!)
+    }
+    when (module.projectDir != null) {
+      projectDir = resolvePath(module.projectDir!!)
     }
   }
 }

--- a/generator-settings.pkl
+++ b/generator-settings.pkl
@@ -17,3 +17,7 @@
 amends "codegen/src/GeneratorSettings.pkl"
 
 generateScript = "codegen/src/Generator.pkl"
+
+projectDir = "codegen/src"
+
+outputPath = "Sources/pkl-gen-swift/Generated"


### PR DESCRIPTION
This allows using project features when running codegen.

Changes:

* Add `--project-dir` flag to pkl-gen-swift CLI
* Add `projectDir` property to `GeneratorSettings.pkl`
* Auto-detect project dir from current working dir if otherwise unspecified