### PR TITLE
Bump minimum Swift version to 5.10

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -125,7 +125,7 @@ jobs {
     ["test-pkl-\(distribution.normalizedVersion)"] {
       docker {
         new {
-          image = "swift:5.9-rhel-ubi9"
+          image = "swift:5.10-rhel-ubi9"
         }
       }
       resource_class = "xlarge"
@@ -161,7 +161,7 @@ jobs {
   ["test-format"] {
     docker {
       new {
-        image = "swift:5.9-rhel-ubi9"
+        image = "swift:5.10-rhel-ubi9"
       }
     }
     steps {
@@ -195,7 +195,7 @@ jobs {
     ["pkl-gen-swift-linux-\(arch)"] {
       docker {
         new {
-          image = "swift:5.9-rhel-ubi9"
+          image = "swift:5.10-rhel-ubi9"
         }
       }
       resource_class = if (arch == "amd64") "xlarge" else "arm.xlarge"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
         path: .out/test-results/
     resource_class: xlarge
     docker:
-    - image: swift:5.9-rhel-ubi9
+    - image: swift:5.10-rhel-ubi9
   test-pkl-0-27-2:
     steps:
     - checkout
@@ -58,7 +58,7 @@ jobs:
         path: .out/test-results/
     resource_class: xlarge
     docker:
-    - image: swift:5.9-rhel-ubi9
+    - image: swift:5.10-rhel-ubi9
   test-license-headers:
     steps:
     - checkout
@@ -72,7 +72,7 @@ jobs:
     - run:
         command: make swiftformat-lint
     docker:
-    - image: swift:5.9-rhel-ubi9
+    - image: swift:5.10-rhel-ubi9
   pkl-gen-swift-macos:
     steps:
     - checkout
@@ -104,7 +104,7 @@ jobs:
         - out/
     resource_class: arm.xlarge
     docker:
-    - image: swift:5.9-rhel-ubi9
+    - image: swift:5.10-rhel-ubi9
   pkl-gen-swift-linux-amd64:
     steps:
     - checkout
@@ -120,7 +120,7 @@ jobs:
         - out/
     resource_class: xlarge
     docker:
-    - image: swift:5.9-rhel-ubi9
+    - image: swift:5.10-rhel-ubi9
   pkl-package:
     steps:
     - checkout

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 //===----------------------------------------------------------------------===//
 // Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
 //


### PR DESCRIPTION
Drop support for Swift 5.9 (5.10, 6.0 and 6.1 are the supported versions)