### PR TITLE
Fix encoding of URL

### DIFF
--- a/Sources/MessagePack/Encoder/SingleValueEncodingContainer.swift
+++ b/Sources/MessagePack/Encoder/SingleValueEncodingContainer.swift
@@ -293,7 +293,7 @@ extension _MessagePackEncoder.SingleValueContainer: SingleValueEncodingContainer
     }
 
     func encode(_ value: URL) throws {
-        try self.encode("\(value)")
+        try self.encode(value.absoluteString)
     }
 
     func encode(_ value: some Encodable) throws {


### PR DESCRIPTION
The string interpolation format creates strings that can look like: `"Sources/Pkl/PklProject -- file:///path/to/swift/project/"`.

The correct way to stringify a URL is to use `.absoluteString`.