### PR TITLE
Make the message parameter to debug lazy

### DIFF
--- a/Sources/PklSwift/Utils.swift
+++ b/Sources/PklSwift/Utils.swift
@@ -16,13 +16,13 @@
 
 import Foundation
 
-let pklDebug = ProcessInfo.processInfo.environment["PKL_DEBUG"]
+let pklDebug = ProcessInfo.processInfo.environment["PKL_DEBUG"] == "1"
 
-func debug(_ message: String) {
-    if pklDebug != "1" {
+func debug(_ message: @autoclosure () -> String) {
+    if !pklDebug {
         return
     }
-    FileHandle.standardError.write("[pkl-swift] \(message)\n".data(using: .utf8)!)
+    FileHandle.standardError.write("[pkl-swift] \(message())\n".data(using: .utf8)!)
     fflush(stderr)
 }
 


### PR DESCRIPTION
The `message` parameter to `debug` may be expensive to compute, and it'll rarely be used in production, so it's better to make it lazy.