### PR TITLE
generate peer classes of an imported typealias

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,8 @@ let package = Package(
                 "Fixtures/Poly.pkl",
                 "Fixtures/ApiTypes.pkl",
                 "Fixtures/Collections2.pkl",
+                "Fixtures/UnusedClass.pkl",
+                "Fixtures/Imports/UnusedClassDefs.pkl"
             ],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -95,7 +95,7 @@ let package = Package(
                 "Fixtures/ApiTypes.pkl",
                 "Fixtures/Collections2.pkl",
                 "Fixtures/UnusedClass.pkl",
-                "Fixtures/Imports/UnusedClassDefs.pkl"
+                "Fixtures/Imports/UnusedClassDefs.pkl",
             ],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),

--- a/Tests/PklSwiftTests/Fixtures/Generated/UnusedClass.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/UnusedClass.pkl.swift
@@ -1,0 +1,37 @@
+// Code generated from Pkl module `UnusedClass`. DO NOT EDIT.
+import PklSwift
+
+public enum UnusedClass {}
+
+extension UnusedClass {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "UnusedClass"
+
+        public var referencedAlias: UnusedClassDefs.ReferencedAlias
+
+        public init(referencedAlias: UnusedClassDefs.ReferencedAlias) {
+            self.referencedAlias = referencedAlias
+        }
+    }
+
+    /// Load the Pkl module at the given source and evaluate it into `UnusedClass.Module`.
+    ///
+    /// - Parameter source: The source of the Pkl module.
+    public static func loadFrom(source: ModuleSource) async throws -> UnusedClass.Module {
+        try await PklSwift.withEvaluator { evaluator in
+            try await loadFrom(evaluator: evaluator, source: source)
+        }
+    }
+
+    /// Load the Pkl module at the given source and evaluate it with the given evaluator into
+    /// `UnusedClass.Module`.
+    ///
+    /// - Parameter evaluator: The evaluator to use for evaluation.
+    /// - Parameter source: The module to evaluate.
+    public static func loadFrom(
+        evaluator: PklSwift.Evaluator,
+        source: PklSwift.ModuleSource
+    ) async throws -> UnusedClass.Module {
+        try await evaluator.evaluateModule(source: source, as: Module.self)
+    }
+}

--- a/Tests/PklSwiftTests/Fixtures/Generated/UnusedClassDefs.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/UnusedClassDefs.pkl.swift
@@ -1,0 +1,41 @@
+// Code generated from Pkl module `UnusedClassDefs`. DO NOT EDIT.
+import PklSwift
+
+public enum UnusedClassDefs {}
+
+extension UnusedClassDefs {
+    public struct Module: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "UnusedClassDefs"
+
+        public init() {}
+    }
+
+    public struct ThisClassShouldAlsoGenerate: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "UnusedClassDefs#ThisClassShouldAlsoGenerate"
+
+        public init() {}
+    }
+
+    public typealias ReferencedAlias = String
+
+    /// Load the Pkl module at the given source and evaluate it into `UnusedClassDefs.Module`.
+    ///
+    /// - Parameter source: The source of the Pkl module.
+    public static func loadFrom(source: ModuleSource) async throws -> UnusedClassDefs.Module {
+        try await PklSwift.withEvaluator { evaluator in
+            try await loadFrom(evaluator: evaluator, source: source)
+        }
+    }
+
+    /// Load the Pkl module at the given source and evaluate it with the given evaluator into
+    /// `UnusedClassDefs.Module`.
+    ///
+    /// - Parameter evaluator: The evaluator to use for evaluation.
+    /// - Parameter source: The module to evaluate.
+    public static func loadFrom(
+        evaluator: PklSwift.Evaluator,
+        source: PklSwift.ModuleSource
+    ) async throws -> UnusedClassDefs.Module {
+        try await evaluator.evaluateModule(source: source, as: Module.self)
+    }
+}

--- a/Tests/PklSwiftTests/Fixtures/Imports/UnusedClassDefs.pkl
+++ b/Tests/PklSwiftTests/Fixtures/Imports/UnusedClassDefs.pkl
@@ -1,0 +1,4 @@
+typealias ReferencedAlias = String
+
+class ThisClassShouldAlsoGenerate {
+}

--- a/Tests/PklSwiftTests/Fixtures/UnusedClass.pkl
+++ b/Tests/PklSwiftTests/Fixtures/UnusedClass.pkl
@@ -1,0 +1,6 @@
+import "Imports/UnusedClassDefs.pkl" as defs
+
+// This test imports UnusedClassDefs, but it ONLY references the typealias and
+// not any of the classes. This caused the Module to be elided by the generator,
+// which results in a compilation failure.
+referencedAlias: defs.ReferencedAlias

--- a/codegen/src/internal/gatherer.pkl
+++ b/codegen/src/internal/gatherer.pkl
@@ -42,7 +42,13 @@ function gatherTypeDeclarations(
         |> gatherModuleTypeAliases(decl)
         |> gatherModule(decl)
   else if (decl is reflect.TypeAlias)
-    seen.add(decl) |> gatherTypeArguments(decl)
+    // If you reference a TypeAlias, gather that alias as well as all of the
+    // other declarations in alias's module. This resolves the issue where a
+    // caller only references a type alias from a module, which would cause
+    // the alias's sibling classes to not generate.
+    seen.add(decl)
+      |> gatherTypeArguments(decl)
+      |> (seen: List<reflect.TypeDeclaration>) -> gatherTypeDeclarations(decl.enclosingDeclaration.moduleClass, seen)
   else seen
 
 /// Tells if this class is part of the stdlib.


### PR DESCRIPTION
pkl-gen-swift doesn't generate the classes for imports if you only reference a typealias from an import that also has classes.

When you gather a typealias, we should also gather the enclosing module, so we pickup any adjacent classes to the typealias. This also adds a test case that fails if you remove this patch (so you can confirm the fix).