### PR TITLE
Change decoder type to `any Decoder`

### DIFF
--- a/Tests/PklSwiftTests/Fixtures/Generated/AnyType.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/AnyType.pkl.swift
@@ -47,7 +47,7 @@ extension AnyType {
             self.dataSize = dataSize
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let bird = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "bird"))
                 .value

--- a/Tests/PklSwiftTests/Fixtures/Generated/OpenModule.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/OpenModule.pkl.swift
@@ -3,7 +3,7 @@ import PklSwift
 
 public enum OpenModule {}
 
-public protocol OpenModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol OpenModule_Module: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var foo: String { get }
 
     var bar: Int { get }

--- a/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/UnionTypes.pkl.swift
@@ -3,11 +3,11 @@ import PklSwift
 
 public enum UnionTypes {}
 
-public protocol UnionTypes_Animal: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol UnionTypes_Animal: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var name: String { get }
 }
 
-public protocol UnionTypes_Shape: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol UnionTypes_Shape: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
 }
 
 extension UnionTypes {

--- a/Tests/PklSwiftTests/Fixtures/Generated/pkl_swift_example_Poly.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/pkl_swift_example_Poly.pkl.swift
@@ -1173,7 +1173,7 @@ extension pkl_swift_example_Poly {
             hasher.combine(foosMapping)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let beings = try dec.decode([PklSwift.PklAny].self, forKey: PklCodingKey(string: "beings"))
                 .map {
@@ -1398,7 +1398,7 @@ extension pkl_swift_example_Poly {
             hasher.combine(exists)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let barks = try dec.decode(Bool.self, forKey: PklCodingKey(string: "barks"))
             let hates = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "hates"))

--- a/Tests/PklSwiftTests/Fixtures/Generated/pkl_swift_lib1.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/pkl_swift_lib1.pkl.swift
@@ -3,7 +3,7 @@ import PklSwift
 
 public enum pkl_swift_lib1 {}
 
-public protocol pkl_swift_lib1_Being: PklRegisteredType, DynamicallyEquatable, Hashable {
+public protocol pkl_swift_lib1_Being: PklRegisteredType, DynamicallyEquatable, Hashable, Sendable {
     var exists: Bool { get }
 }
 

--- a/codegen/snippet-tests/output/Classes.pkl.swift
+++ b/codegen/snippet-tests/output/Classes.pkl.swift
@@ -152,7 +152,7 @@ extension Classes {
             hasher.combine(bugTypeAlias)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let owner = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "owner"))
                 .value as! (any Person)?
@@ -288,7 +288,7 @@ extension Classes {
             hasher.combine(isAlive)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let myself = try dec.decode(ThisPerson.self, forKey: PklCodingKey(string: "myself"))
             let someoneElse = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "someoneElse"))

--- a/codegen/snippet-tests/output/ExtendsAbstractClass.pkl.swift
+++ b/codegen/snippet-tests/output/ExtendsAbstractClass.pkl.swift
@@ -25,7 +25,7 @@ extension ExtendsAbstractClass {
             hasher.combine(a)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let a = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "a"))
                 .value as! any A

--- a/codegen/snippet-tests/output/Foo.pkl.swift
+++ b/codegen/snippet-tests/output/Foo.pkl.swift
@@ -31,7 +31,7 @@ extension Foo {
             }
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let animals = try dec.decode([PklSwift.PklAny].self, forKey: PklCodingKey(string: "animals"))
                 .map {

--- a/codegen/snippet-tests/output/com_example_Simple.pkl.swift
+++ b/codegen/snippet-tests/output/com_example_Simple.pkl.swift
@@ -32,7 +32,7 @@ extension com_example_Simple {
             hasher.combine(person)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let person = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "person"))
                 .value as! any Person

--- a/codegen/snippet-tests/output/override.pkl.swift
+++ b/codegen/snippet-tests/output/override.pkl.swift
@@ -25,7 +25,7 @@ extension override {
             hasher.combine(foo)
         }
 
-        public init(from decoder: Decoder) throws {
+        public init(from decoder: any Decoder) throws {
             let dec = try decoder.container(keyedBy: PklCodingKey.self)
             let foo = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "foo"))
                 .value as! any Foo

--- a/codegen/src/internal/ClassGen.pkl
+++ b/codegen/src/internal/ClassGen.pkl
@@ -281,7 +281,7 @@ local function renderInitDecoderInner(type: Type, rpt: Int, prefix: String, opt:
 
 local synthesizedInitDecoder =
   new Listing {
-    "\(module.indent)public init(from decoder: Decoder) throws {\n"
+    "\(module.indent)public init(from decoder: any Decoder) throws {\n"
     "\(module.indent.repeat(2))let dec = try decoder.container(keyedBy: PklCodingKey.self)\n"
     for (pklPropertyName, field in properties) {
       "\(module.indent.repeat(2))let \(field.name) = try dec.decode("


### PR DESCRIPTION
Addresses a compiler warning emitted by Swift:

```
Use of protocol 'Decoder' as a type must be written 'any Decoder'; this will be an error in a future Swift language mode
```