### PR TITLE
Process spawn fix

### DIFF
--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -339,7 +339,7 @@ public actor EvaluatorManager {
                 }
             }
         }
-        
+
         self.transport.close()
     }
 


### PR DESCRIPTION
Hello Pkl team!

What I have recently found is that Pkl processes are not correctly terminated when evaluating modules in a loop in certain conditions. I believe this happens when the process doing the evaluation also provides some external readers.

Basically, for every evaluation, the process would be run once, then the call to evaluator.close() happens, which terminates the process. After that, I suppose (please correct me if I'm wrong), the CloseEvaluatorRequest which was previously sent, triggers a call to ServerMessageTransport.ensureProcessStarted, which restart the process again.

But since we're in the closing phase of the evaluator object, the second process never terminates.

My fix was to actually wait for all calls to closeEvaluator in EvaluatorManager.close() before terminating the transport. I did this through a task group.