### PR TITLE
Allow custom/external resources to be "not found"

### DIFF
--- a/Sources/PklSwift/Evaluator.swift
+++ b/Sources/PklSwift/Evaluator.swift
@@ -222,13 +222,11 @@ public struct Evaluator: Sendable {
             return
         }
         do {
-            let result = try await reader.read(url: request.uri)
-            response.contents = result
-            try await self.manager.tell(response)
+            response.contents = try await reader.read(url: request.uri)
         } catch {
             response.error = "\(error)"
-            try await self.manager.tell(response)
         }
+        try await self.manager.tell(response)
     }
 
     func handleReadResourceRequest(request: ReadResourceRequest) async throws {
@@ -244,13 +242,11 @@ public struct Evaluator: Sendable {
             return
         }
         do {
-            let result = try await reader.read(url: request.uri)
-            response.contents = result
-            try await self.manager.tell(response)
+            response.contents = try await reader.read(url: request.uri)
         } catch {
             response.error = "\(error)"
-            try await self.manager.tell(response)
         }
+        try await self.manager.tell(response)
     }
 
     func handleListModulesRequest(request: ListModulesRequest) async throws {
@@ -266,13 +262,11 @@ public struct Evaluator: Sendable {
             return
         }
         do {
-            let elems = try await reader.listElements(uri: request.uri)
-            response.pathElements = elems.map { $0.toMessage() }
-            try await self.manager.tell(response)
+            response.pathElements = try await reader.listElements(uri: request.uri).map { $0.toMessage() }
         } catch {
             response.error = "\(error)"
-            try await self.manager.tell(response)
         }
+        try await self.manager.tell(response)
     }
 
     func handleListResourcesRequest(request: ListResourcesRequest) async throws {
@@ -288,13 +282,11 @@ public struct Evaluator: Sendable {
             return
         }
         do {
-            let elems = try await reader.listElements(uri: request.uri)
-            response.pathElements = elems.map { $0.toMessage() }
-            try await self.manager.tell(response)
+            response.pathElements = try await reader.listElements(uri: request.uri).map { $0.toMessage() }
         } catch {
             response.error = "\(error)"
-            try await self.manager.tell(response)
         }
+        try await self.manager.tell(response)
     }
 
     func handleLog(request: LogMessage) {

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -397,10 +397,12 @@ enum PklBugError: Error {
 let pklVersion0_25 = SemanticVersion("0.25.0")!
 let pklVersion0_26 = SemanticVersion("0.26.0")!
 let pklVersion0_27 = SemanticVersion("0.27.0")!
+let pklVersion0_27_2 = SemanticVersion("0.27.2")!
 let pklVersion0_28 = SemanticVersion("0.28.0")!
 let pklVersion0_29 = SemanticVersion("0.29.0")!
 let pklVersion0_30 = SemanticVersion("0.30.0")!
 let pklVersion0_31 = SemanticVersion("0.31.0")!
+let pklVersion0_31_1 = SemanticVersion("0.31.1")!
 
 let supportedPklVersions = [
     pklVersion0_25,

--- a/Sources/PklSwift/ExternalReaderClient.swift
+++ b/Sources/PklSwift/ExternalReaderClient.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,13 +129,11 @@ public actor ExternalReaderClient {
             return
         }
         do {
-            let result = try await reader.read(url: request.uri)
-            response.contents = result
-            try self.transport.send(response)
+            response.contents = try await reader.read(url: request.uri)
         } catch {
             response.error = "\(error)"
-            try self.transport.send(response)
         }
+        try self.transport.send(response)
     }
 
     func handleReadResourceRequest(request: ReadResourceRequest) async throws {
@@ -152,13 +150,11 @@ public actor ExternalReaderClient {
             return
         }
         do {
-            let result = try await reader.read(url: request.uri)
-            response.contents = result
-            try self.transport.send(response)
+            response.contents = try await reader.read(url: request.uri)
         } catch {
             response.error = "\(error)"
-            try self.transport.send(response)
         }
+        try self.transport.send(response)
     }
 
     func handleListModulesRequest(request: ListModulesRequest) async throws {
@@ -174,13 +170,11 @@ public actor ExternalReaderClient {
             return
         }
         do {
-            let elems = try await reader.listElements(uri: request.uri)
-            response.pathElements = elems.map { $0.toMessage() }
-            try self.transport.send(response)
+            response.pathElements = try await reader.listElements(uri: request.uri).map { $0.toMessage() }
         } catch {
             response.error = "\(error)"
-            try self.transport.send(response)
         }
+        try self.transport.send(response)
     }
 
     func handleListResourcesRequest(request: ListResourcesRequest) async throws {
@@ -197,12 +191,10 @@ public actor ExternalReaderClient {
             return
         }
         do {
-            let elems = try await reader.listElements(uri: request.uri)
-            response.pathElements = elems.map { $0.toMessage() }
-            try self.transport.send(response)
+            response.pathElements = try await reader.listElements(uri: request.uri).map { $0.toMessage() }
         } catch {
             response.error = "\(error)"
-            try self.transport.send(response)
         }
+        try self.transport.send(response)
     }
 }

--- a/Sources/PklSwift/Reader.swift
+++ b/Sources/PklSwift/Reader.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ extension ModuleReader {
 
 public protocol ResourceReader: BaseReader {
     /// Reads resources from the provided URL into a byte array.
-    func read(url: URL) async throws -> [UInt8]
+    func read(url: URL) async throws -> [UInt8]?
 }
 
 extension ResourceReader {

--- a/Sources/test-external-reader/TestExternalReader.swift
+++ b/Sources/test-external-reader/TestExternalReader.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,12 +33,16 @@ struct FibReader: ResourceReader {
     var isGlobbable: Bool { false }
     var hasHierarchicalUris: Bool { false }
     func listElements(uri: URL) async throws -> [PathElement] { throw PklError("not implemented") }
-    func read(url: URL) async throws -> [UInt8] {
+    func read(url: URL) async throws -> [UInt8]? {
         let key = url.absoluteString.dropFirst(self.scheme.count + 1)
-        guard let n = Int(key), n > 0 else {
+        guard let n = Int(key) else {
             throw PklError("input uri must be in format fib:<positive integer>")
         }
-        return Array(String(fibonacci(n: n)).utf8)
+        switch n {
+        case ..<0: throw PklError("input uri must be in format fib:<positive integer>")
+        case 0: return nil
+        default: return Array(String(fibonacci(n: n)).utf8)
+        }
     }
 }
 

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,11 +61,11 @@ struct VirtualResourceReader: ResourceReader {
 
     var hasHierarchicalUris: Bool
 
-    var read: @Sendable (URL) async throws -> [UInt8]
+    var read: @Sendable (URL) async throws -> [UInt8]?
 
     var listElements: @Sendable (URL) async throws -> [PathElement]
 
-    func read(url: URL) async throws -> [UInt8] {
+    func read(url: URL) async throws -> [UInt8]? {
         try await self.read(url)
     }
 
@@ -345,6 +345,27 @@ final class PklSwiftTests: XCTestCase {
         result = read("pizza:pizza").text
         """))
         XCTAssertEqual(output, #"result = "yes pizza"\#n"#)
+    }
+
+    func testCustomResourceReaderNotFound() async throws {
+        let version = try await SemanticVersion(EvaluatorManager().getVersion())!
+        guard version >= pklVersion0_27_2 else {
+            throw XCTSkip("Pkl versions prior to 0.27.2 NPE during this test.")
+        }
+
+        let reader = VirtualResourceReader(
+            scheme: "pizza",
+            isGlobbable: false,
+            hasHierarchicalUris: false,
+            read: { _ in nil },
+            listElements: { _ in [] }
+        )
+        let options = EvaluatorOptions.preconfigured.withResourceReader(reader)
+        let evaluator = try await manager.newEvaluator(options: options)
+        let output = try await evaluator.evaluateOutputText(source: .text("""
+        result = read?("pizza:pizza")?.text
+        """))
+        XCTAssertEqual(output, #"result = \#(version >= pklVersion0_31_1 ? "null" : "\"\"")\#n"#)
     }
 
     func testCustomResourceReaderWithSchemeContainingRegexControlCharacters() async throws {

--- a/Tests/PklSwiftTests/ExternalReaderClientTest.swift
+++ b/Tests/PklSwiftTests/ExternalReaderClientTest.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import XCTest
 class ExternalReaderClientTest: XCTestCase {
     func testE2E() async throws {
         let version = try await SemanticVersion(EvaluatorManager().getVersion())!
-        guard version >= pklVersion0_27 else {
+        guard version >= pklVersion0_27_2 else {
             throw XCTSkip("External readers require Pkl 0.27 or later.")
         }
 
@@ -48,6 +48,40 @@ class ExternalReaderClientTest: XCTestCase {
         fibErrA = "I/O error reading resource `fib:%20`. IOException: PklError(message: \\"input uri must be in format fib:<positive integer>\\")"
         fibErrB = "I/O error reading resource `fib:abc`. IOException: PklError(message: \\"input uri must be in format fib:<positive integer>\\")"
         fibErrC = "I/O error reading resource `fib:-10`. IOException: PklError(message: \\"input uri must be in format fib:<positive integer>\\")"
+        """
+
+        let opts = EvaluatorOptions(
+            allowedModules: ["file:", "repl:text"],
+            allowedResources: ["fib:", "prop:"],
+            externalResourceReaders: [
+                "fib": ExternalReader(executable: "./.build/debug/test-external-reader"),
+            ]
+        )
+
+        try await withEvaluator(options: opts) { evaluator in
+            let result = try await evaluator.evaluateOutputText(source: .url(testFile))
+            XCTAssertEqual(result.trimmingCharacters(in: .whitespacesAndNewlines), expectedResult.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+    }
+
+    func testNotFound() async throws {
+        let version = try await SemanticVersion(EvaluatorManager().getVersion())!
+        guard version >= pklVersion0_27_2 else {
+            throw XCTSkip("External readers require Pkl 0.27 or later.")
+        }
+
+        let tempDir = try tempDir()
+        let testFile = tempDir.appendingPathComponent("test.pkl")
+        try #"""
+        import "pkl:test"
+
+        fibNullable0 = read?("fib:0")?.text
+        fibErrNotFound = test.catchOrNull(() -> read("fib:0").text)
+        """#.write(to: testFile, atomically: true, encoding: .utf8)
+
+        let expectedResult = """
+        fibNullable0 = \(version >= pklVersion0_31_1 ? "null" : "\"\"")
+        fibErrNotFound = \(version >= pklVersion0_31_1 ? "\"Cannot find resource `fib:0`.\"" : "null")
         """
 
         let opts = EvaluatorOptions(


### PR DESCRIPTION
This allows custom/external resources to produce `null` values for nullable reads (`read?`)

Ref: https://github.com/apple/pkl-go/issues/157

Requires Pkl runtime with https://github.com/apple/pkl/pull/1471