### PR TITLE
Use POSIX read() for pipe I/O to avoid NSConcreteData allocation churn

### DIFF
--- a/Sources/PklSwift/MessageTransport.swift
+++ b/Sources/PklSwift/MessageTransport.swift
@@ -41,18 +41,20 @@ extension Pipe: Reader {
 
 extension FileHandle: Reader {
     public func read(into: UnsafeMutableRawBufferPointer) throws -> Int {
-        // Loop until all requested bytes are read or EOF.  read(upToCount:) may
-        // return fewer bytes than requested when data arrives in chunks (e.g., the
-        // JVM writes through an 8 KB BufferedOutputStream).  A short read leaves
-        // bytes in the pipe that the decoder then misinterprets as the start of the
-        // next message, desynchronising the stream and triggering the
-        // guard(arrayLength == 2) error in getMessages().
+        // Read directly into the caller's buffer via POSIX read() to avoid
+        // the per-call NSConcreteData allocation from NSFileHandle.read(upToCount:).
+        // Loop until all requested bytes are read or EOF — short reads are
+        // normal on pipes (e.g., the JVM writes through an 8 KB BufferedOutputStream).
+        guard let base = into.baseAddress else { return 0 }
+        let fd = fileDescriptor
         var totalRead = 0
         while totalRead < into.count {
-            let slice = UnsafeMutableRawBufferPointer(rebasing: into[totalRead...])
-            guard let data = try read(upToCount: slice.count), !data.isEmpty else { break }
-            data.copyBytes(to: slice)
-            totalRead += data.count
+            let n = Foundation.read(fd, base + totalRead, into.count - totalRead)
+            if n < 0 {
+                throw POSIXError(.init(rawValue: errno) ?? .EIO)
+            }
+            if n == 0 { break }
+            totalRead += n
         }
         return totalRead
     }


### PR DESCRIPTION
## Summary

- Replace `NSFileHandle.read(upToCount:)` with POSIX `read()` in the `FileHandle` `Reader` conformance
- Eliminates per-call `NSConcreteData` backing buffer allocation — reads directly into the caller's `UnsafeMutableRawBufferPointer`

## Problem

`NSFileHandle.read(upToCount:)` allocates a fresh `NSConcreteData` backing buffer (8-10 KB) on every call.
On large workloads, the cumulative allocation churn consumes hundreds of megabytes and fragments the malloc heap.
The buffers are immediately discarded after `copyBytes(to:)` — pure allocation churn.

## Fix

POSIX `read()` writes directly into the caller's provided buffer.
The kernel copies bytes straight into the target `UnsafeMutableRawBufferPointer` with zero intermediate allocations.
The short-read retry loop is preserved.