### PR TITLE
Fix typo in quickstart guide

### DIFF
--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -76,7 +76,7 @@ With the above scaffolding set up, evaluate Pkl configuration data in Swift.
 
 First, define some configuration that uses the Pkl schema.
 
-In our example, we create a file at path `pkl/local/appConfig.pkl`. We imagine that we are defining configuration for a server running in a local environment, and would likewise place other environments in sibling directorys; e.g. `pkl/int/appConfig.pkl` and `pkl/prod/appConfig.pkl`.
+In our example, we create a file at path `pkl/local/appConfig.pkl`. We imagine that we are defining configuration for a server running in a local environment, and would likewise place other environments in sibling directories; e.g. `pkl/int/appConfig.pkl` and `pkl/prod/appConfig.pkl`.
 
 .pkl/local/appConfig.pkl
 [source,pkl]


### PR DESCRIPTION
Fix "directorys" to "directories" in quickstart documentation.