### PR TITLE
fix: preserve caCertificates when merging HTTP settings from PklProject evaluatorSettings

### DIFF
--- a/Sources/PklSwift/EvaluatorOptions.swift
+++ b/Sources/PklSwift/EvaluatorOptions.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklSwift/EvaluatorOptions.swift
+++ b/Sources/PklSwift/EvaluatorOptions.swift
@@ -277,6 +277,7 @@ extension EvaluatorOptions {
         options.rootDir = evaluatorSettings.rootDir ?? self.rootDir
         if let http = evaluatorSettings.http {
             options.http = .init()
+            options.http!.caCertificates = http.caCertificates ?? self.http?.caCertificates
             if let proxy = http.proxy {
                 options.http!.proxy = .init()
                 options.http!.proxy!.noProxy = proxy.noProxy ?? self.http?.proxy?.noProxy


### PR DESCRIPTION
withProjectEvaluatorSettings merges proxy and rewrites from the project's HTTP config but silently drops caCertificates, causing TLS failures when projects specify custom CA certificates for internal servers.