### PR TITLE
fix: correct MessageType mapping for ListResourcesResponse

### DIFF
--- a/Sources/PklSwift/Message.swift
+++ b/Sources/PklSwift/Message.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklSwift/Message.swift
+++ b/Sources/PklSwift/Message.swift
@@ -98,7 +98,7 @@ extension MessageType {
         case is ListResourcesRequest:
             return MessageType.LIST_RESOURCES_REQUEST
         case is ListResourcesResponse:
-            return MessageType.LIST_MODULES_RESPONSE
+            return MessageType.LIST_RESOURCES_RESPONSE
         case is ListModulesRequest:
             return MessageType.LIST_MODULES_REQUEST
         case is ListModulesResponse:


### PR DESCRIPTION
ListResourcesResponse was incorrectly mapped to LIST_MODULES_RESPONSE (0x2D) instead of LIST_RESOURCES_RESPONSE (0x2B) in MessageType.getMessageType().

This caused the Swift client to send responses to ListResourcesRequest messages with the wrong message type code (0x2D instead of 0x2B), which would cause Pkl to misinterpret or reject the response when custom resource readers with globbing support (import*/glob*) are used.

Fixes the message type tag from LIST_MODULES_RESPONSE to LIST_RESOURCES_RESPONSE to match the Pkl server protocol specification.