### PR TITLE
Rename MessagePack module to PklMessagePack to avoid naming conflicts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "MessagePack",
-            targets: ["MessagePack"]
+            name: "PklMessagePack",
+            targets: ["PklMessagePack"]
         ),
         .library(
             name: "PklSwift",
@@ -47,7 +47,7 @@ let package = Package(
     targets: [
         .target(
             name: "PklSwift",
-            dependencies: ["MessagePack", "PklSwiftInternals", "SemanticVersion"],
+            dependencies: ["PklMessagePack", "PklSwiftInternals", "SemanticVersion"],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")],
         ),
         .target(
@@ -55,7 +55,7 @@ let package = Package(
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),
         .target(
-            name: "MessagePack",
+            name: "PklMessagePack",
             dependencies: [
                 .product(name: "SystemPackage", package: "swift-system"),
             ],
@@ -88,9 +88,9 @@ let package = Package(
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),
         .testTarget(
-            name: "MessagePackTests",
+            name: "PklMessagePackTests",
             dependencies: [
-                "MessagePack",
+                "PklMessagePack",
             ],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]
         ),

--- a/Sources/PklMessagePack/AnyCodingKey.swift
+++ b/Sources/PklMessagePack/AnyCodingKey.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Box.swift
+++ b/Sources/PklMessagePack/Box.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/KeyedDecodingContainer.swift
+++ b/Sources/PklMessagePack/Decoder/KeyedDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/KeyedSingleDecodingContainer.swift
+++ b/Sources/PklMessagePack/Decoder/KeyedSingleDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/MessagePackDecoder.swift
+++ b/Sources/PklMessagePack/Decoder/MessagePackDecoder.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/SingleValueDecodingContainer.swift
+++ b/Sources/PklMessagePack/Decoder/SingleValueDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/UnkeyedDecodingContainer.swift
+++ b/Sources/PklMessagePack/Decoder/UnkeyedDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/UnkeyedMapDecodingContainer.swift
+++ b/Sources/PklMessagePack/Decoder/UnkeyedMapDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Decoder/_MessagePackDecoder.swift
+++ b/Sources/PklMessagePack/Decoder/_MessagePackDecoder.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Encoder/KeyedEncodingContainer.swift
+++ b/Sources/PklMessagePack/Encoder/KeyedEncodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Encoder/MessagePackEncoder.swift
+++ b/Sources/PklMessagePack/Encoder/MessagePackEncoder.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Encoder/SingleValueEncodingContainer.swift
+++ b/Sources/PklMessagePack/Encoder/SingleValueEncodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/Encoder/UnkeyedEncodingContainer.swift
+++ b/Sources/PklMessagePack/Encoder/UnkeyedEncodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/FixedWidthInteger.swift
+++ b/Sources/PklMessagePack/FixedWidthInteger.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklMessagePack/IO.swift
+++ b/Sources/PklMessagePack/IO.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Sources/PklSwift/API/Class.swift
+++ b/Sources/PklSwift/API/Class.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 /// Class is the Swift representation of Pkl's `pkl.base#Class`.
 public struct Class: Hashable {

--- a/Sources/PklSwift/API/DataSize.swift
+++ b/Sources/PklSwift/API/DataSize.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 
 /// DataSize is the Swift representation of Pkl's `pkl.DataSize`.
 public struct DataSize: Hashable, Sendable {

--- a/Sources/PklSwift/API/TypeAlias.swift
+++ b/Sources/PklSwift/API/TypeAlias.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 /// TypeAlias is the Swift representation of Pkl's `pkl.base#TypeAlias`.
 public struct TypeAlias: Hashable {

--- a/Sources/PklSwift/Decoder/PklDecoder.swift
+++ b/Sources/PklSwift/Decoder/PklDecoder.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 
 public enum PklValueType: UInt8, Decodable, Sendable {
     case object = 0x01

--- a/Sources/PklSwift/Decoder/PklMapDecodingContainer.swift
+++ b/Sources/PklSwift/Decoder/PklMapDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 extension _PklDecoder {
     /// Decoding container that handles `Map` and `Mapping`.

--- a/Sources/PklSwift/Decoder/PklSingleValueDecodingContainer.swift
+++ b/Sources/PklSwift/Decoder/PklSingleValueDecodingContainer.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 class PklSingleValueDecodingContainer: SingleValueDecodingContainer {
     private let value: MessagePackValue

--- a/Sources/PklSwift/Decoder/PklTypedDecodingContainer.swift
+++ b/Sources/PklSwift/Decoder/PklTypedDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 extension _PklDecoder {
     fileprivate static func deriveProperties(

--- a/Sources/PklSwift/Decoder/PklUnkeyedDecodingContainer.swift
+++ b/Sources/PklSwift/Decoder/PklUnkeyedDecodingContainer.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 
 extension _PklDecoder {
     class PklUnkeyedDecodingContainer: UnkeyedDecodingContainer {

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 import SemanticVersion
 #if os(Windows)
 import WinSDK.System

--- a/Sources/PklSwift/ExternalReaderClient.swift
+++ b/Sources/PklSwift/ExternalReaderClient.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 
 // Example usage:
 // import PklSwift

--- a/Sources/PklSwift/Logger.swift
+++ b/Sources/PklSwift/Logger.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 
 /// Handler to control logging messages emitted by the Pkl evaluator.
 ///

--- a/Sources/PklSwift/Message.swift
+++ b/Sources/PklSwift/Message.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 
 protocol Message: Codable, Sendable {}
 

--- a/Sources/PklSwift/MessageTransport.swift
+++ b/Sources/PklSwift/MessageTransport.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import MessagePack
+import PklMessagePack
 import SemanticVersion
 
 protocol MessageTransport: Sendable {

--- a/Sources/PklSwift/TypeRegistry.swift
+++ b/Sources/PklSwift/TypeRegistry.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import MessagePack
+import PklMessagePack
 import PklSwiftInternals
 
 /// Marker protocol that all generated Pkl types should conform to.

--- a/Tests/PklMessagePackTests/MessagePackDecodingTests.swift
+++ b/Tests/PklMessagePackTests/MessagePackDecodingTests.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import MessagePack
+@testable import PklMessagePack
 
 struct Person: Codable, Hashable {
     let name: String

--- a/Tests/PklMessagePackTests/MessagePackEncodingTests.swift
+++ b/Tests/PklMessagePackTests/MessagePackEncodingTests.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import XCTest
 
-@testable import MessagePack
+@testable import PklMessagePack
 
 final class MessagePackEncodingTests: XCTestCase {
     var writer: BufferWriter?

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-@testable import MessagePack
+@testable import PklMessagePack
 @testable import PklSwift
 import SemanticVersion
 import XCTest

--- a/Tests/PklSwiftTests/MessageTransportTest.swift
+++ b/Tests/PklSwiftTests/MessageTransportTest.swift
@@ -17,7 +17,7 @@
 import Foundation
 import XCTest
 
-@testable import MessagePack
+@testable import PklMessagePack
 @testable import PklSwift
 
 /// Tests for pipe partial-read handling in ``MessageTransport``.


### PR DESCRIPTION
Avoid a SwiftPM target naming conflict with other packages that provide a general-purpose MessagePack implementation.