### PR TITLE
SPICE-0020: Type-safe deferred references

### DIFF
--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -25,7 +25,7 @@ import "@pkl.impl.ghactions/steps/SetupPkl.pkl"
 
 local swiftImage = "swift:6.1-rhel-ubi9"
 local xcodeVersion = "26.1"
-local pklCurrent: String(semver.isValid(this)) = "0.31.0"
+local pklCurrent: String(semver.isValid(this)) = "0.32.0"
 local pklDistributions: Listing<String(semver.isValid(this))> = new {
   "0.25.3"
   pklCurrent
@@ -47,7 +47,7 @@ local class SimulatorRuntime {
       "watchOS Simulator", "watchsimulator",
       "tvOS Simulator", "appletvsimulator",
       "visionOS Simulator", "xrsimulator",
-      "Mac Catalyst", "macosx"
+      "Mac Catalyst", "macosx",
     )[platform]
 
   hidden destination: String = "platform=\(platform),name=\(name)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
-  test-pkl-0-31-0:
-    name: Test Pkl 0.31.0
+  test-pkl-0-32-0:
+    name: Test Pkl 0.32.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -57,9 +57,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -80,7 +80,7 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: test-results-xml-test-pkl-0-31-0
+        name: test-results-xml-test-pkl-0-32-0
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
@@ -232,9 +232,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -248,7 +248,7 @@ jobs:
     if: '!cancelled()'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
-  test-pkl-0-31-0:
-    name: Test Pkl 0.31.0
+  test-pkl-0-32-0:
+    name: Test Pkl 0.32.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -55,9 +55,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -78,7 +78,7 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: test-results-xml-test-pkl-0-31-0
+        name: test-results-xml-test-pkl-0-32-0
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
@@ -230,9 +230,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -246,7 +246,7 @@ jobs:
     if: '!cancelled()'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator

--- a/.github/workflows/prb.yml
+++ b/.github/workflows/prb.yml
@@ -42,8 +42,8 @@ jobs:
         if-no-files-found: ignore
     container:
       image: swift:6.1-rhel-ubi9
-  test-pkl-0-31-0:
-    name: Test Pkl 0.31.0
+  test-pkl-0-32-0:
+    name: Test Pkl 0.32.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -52,9 +52,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -75,7 +75,7 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: test-results-xml-test-pkl-0-31-0
+        name: test-results-xml-test-pkl-0-32-0
         path: .out/test-results/**/*.xml
         if-no-files-found: ignore
     container:
@@ -232,9 +232,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -249,7 +249,7 @@ jobs:
     needs:
     - check-pkl-github-actions
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -45,8 +45,8 @@ jobs:
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
-  test-pkl-0-31-0:
-    name: Test Pkl 0.31.0
+  test-pkl-0-32-0:
+    name: Test Pkl 0.32.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -55,9 +55,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -78,7 +78,7 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: test-results-xml-test-pkl-0-31-0
+        name: test-results-xml-test-pkl-0-32-0
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
@@ -230,9 +230,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -246,7 +246,7 @@ jobs:
     if: '!cancelled()'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator
@@ -268,7 +268,7 @@ jobs:
     if: github.repository_owner == 'apple'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,8 @@ jobs:
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
-  test-pkl-0-31-0:
-    name: Test Pkl 0.31.0
+  test-pkl-0-32-0:
+    name: Test Pkl 0.32.0
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -55,9 +55,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -78,7 +78,7 @@ jobs:
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
-        name: test-results-xml-test-pkl-0-31-0
+        name: test-results-xml-test-pkl-0-32-0
         path: .out/test-results/**/*.xml
     container:
       image: swift:6.1-rhel-ubi9
@@ -230,9 +230,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -245,7 +245,7 @@ jobs:
   build-pkl-package:
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator
@@ -261,9 +261,9 @@ jobs:
     - name: Setup Pkl
       id: setup-pkl
       env:
-        PKL_VERSION: 0.31.0
+        PKL_VERSION: 0.32.0
         PKL_FILENAME: pkl
-        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.31.0/pkl-linux-amd64
+        PKL_DOWNLOAD_URL: https://github.com/apple/pkl/releases/download/0.32.0/pkl-linux-amd64
       shell: bash
       run: |-
         DIR="$(mktemp -d /tmp/pkl-$PKL_VERSION-XXXXXX)"
@@ -323,7 +323,7 @@ jobs:
     if: '!cancelled()'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator
@@ -345,7 +345,7 @@ jobs:
     if: github.repository_owner == 'apple'
     needs:
     - test-pkl-0-25-3
-    - test-pkl-0-31-0
+    - test-pkl-0-32-0
     - test-sim-ios-simulator
     - test-sim-watchos-simulator
     - test-sim-tvos-simulator

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ license-format: .build/tools/hawkeye
 
 .PHONY: pkl-format
 pkl-format:
-	$(PKL_EXEC) format --grammar-version 1 --write .
+	$(PKL_EXEC) format --write .
 
 .PHONY: pkl-format-lint
 pkl-format-lint:
-	$(PKL_EXEC) format --grammar-version 1 --diff-name-only .
+	$(PKL_EXEC) format --diff-name-only .
 
 .PHONY: format
 format: swiftformat license-format pkl-format

--- a/Package.swift
+++ b/Package.swift
@@ -83,6 +83,7 @@ let package = Package(
                 "Fixtures/Poly.pkl",
                 "Fixtures/ApiTypes.pkl",
                 "Fixtures/UnusedClass.pkl",
+                "Fixtures/Ref.pkl",
                 "Fixtures/Imports/UnusedClassDefs.pkl",
             ],
             swiftSettings: [.enableUpcomingFeature("StrictConcurrency")]

--- a/Sources/PklSwift/API/Reference.swift
+++ b/Sources/PklSwift/API/Reference.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import PklMessagePack
+
+/// Reference is the Swift representation of Pkl's `pkl.ref#Reference`.
+public struct Reference<D: Hashable>: Hashable, @unchecked Sendable {
+    /// Reference domain.
+    public let domain: D
+
+    /// Reference data.
+    public let data: AnyHashable?
+
+    /// Reference access path.
+    public let path: [ReferenceAccess]
+
+    public static var messageTag: PklValueType { .reference }
+}
+
+extension Reference: PklSerializableType {
+    public static func decode(_ fields: [MessagePackValue], codingPath: [any CodingKey]) throws -> Reference {
+        try checkFieldCount(fields, codingPath: codingPath, min: 3)
+        let pathCodingPath = codingPath + [PklCodingKey(intValue: 3)!]
+        guard case .array(let path) = fields[3] else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: pathCodingPath,
+                    debugDescription: "Expected array type but got \(fields[3].debugDescription)"
+                ))
+        }
+        return try Reference(
+            domain: _PklDecoder.decodePolymorphic(
+                fields[1],
+                codingPath: codingPath + [PklCodingKey(intValue: 1)!]
+            )?.value as! D,
+            data: _PklDecoder.decodePolymorphic(
+                fields[2],
+                codingPath: codingPath + [PklCodingKey(intValue: 2)!]
+            )?.value,
+            path: path.enumerated().map {
+                try ReferenceAccess(from: _PklDecoder(
+                    value: $0.1,
+                    codingPath: pathCodingPath + [PklCodingKey(intValue: $0.0)!]
+                ))
+            },
+        )
+    }
+}
+
+/// ReferenceAccess is the Swift representation of Pkl's `pkl.ref#Access`.
+public enum ReferenceAccess: PklRegisteredType, Decodable, Hashable, @unchecked Sendable {
+    public static let registeredIdentifier: String = "pkl.ref#Access"
+
+    case property(String)
+    case subscriptKey(AnyHashable?)
+
+    public init(from decoder: any Decoder) throws {
+        let dec = try decoder.container(keyedBy: PklCodingKey.self)
+        if let property = try dec.decode(String?.self, forKey: PklCodingKey(string: "property")) {
+            self = .property(property)
+        } else {
+            self = try .subscriptKey(dec.decode(PklAny.self, forKey: PklCodingKey(string: "key")).value)
+        }
+    }
+}

--- a/Sources/PklSwift/Decoder/PklDecoder.swift
+++ b/Sources/PklSwift/Decoder/PklDecoder.swift
@@ -33,6 +33,8 @@ public enum PklValueType: UInt8, Decodable, Sendable {
     case `typealias` = 0x0D
     case function = 0x0E
     case bytes = 0x0F
+    case reference = 0x20
+
     case objectMemberProperty = 0x10
     case objectMemberEntry = 0x11
     case objectMemberElement = 0x12
@@ -304,6 +306,9 @@ extension _PklDecoder {
                         ))
                 }
                 return PklAny(value: bytes)
+            case .reference:
+                let decoder = try _PklDecoder(value: propertyValue)
+                return try PklAny(value: Reference<AnyHashable?>(from: decoder))
             default:
                 throw DecodingError.dataCorrupted(
                     .init(

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -451,6 +451,7 @@ let pklVersion0_29 = SemanticVersion("0.29.0")!
 let pklVersion0_30 = SemanticVersion("0.30.0")!
 let pklVersion0_31 = SemanticVersion("0.31.0")!
 let pklVersion0_31_1 = SemanticVersion("0.31.1")!
+let pklVersion0_32 = SemanticVersion("0.32.0")!
 
 let supportedPklVersions = [
     pklVersion0_25,
@@ -460,4 +461,5 @@ let supportedPklVersions = [
     pklVersion0_29,
     pklVersion0_30,
     pklVersion0_31,
+    pklVersion0_32,
 ]

--- a/Sources/PklSwift/Utils.swift
+++ b/Sources/PklSwift/Utils.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -118,6 +118,8 @@ public struct OptionalDictionaryKey<Wrapped>: Hashable, Decodable, CodingKeyRepr
         fatalError("cannot initialize OptionalDictionaryKey from CodingKey")
     }
 }
+
+extension OptionalDictionaryKey: Sendable where Wrapped: Sendable {}
 
 private let regexSpecialCharacters = CharacterSet(charactersIn: #"\.+*?()|[]{}^$"#)
 

--- a/Tests/PklSwiftTests/Fixtures/Generated/Ref.pkl.swift
+++ b/Tests/PklSwiftTests/Fixtures/Generated/Ref.pkl.swift
@@ -1,0 +1,138 @@
+// Code generated from Pkl module `Ref`. DO NOT EDIT.
+import PklSwift
+
+public enum Ref {}
+
+extension Ref {
+    public enum MapKeyValue: Decodable, Hashable, Sendable {
+        case string(String)
+        case int(Int)
+
+        private static func decodeNumeric(from decoder: any Decoder, _ container: any SingleValueDecodingContainer) -> MapKeyValue? {
+            return try? .int(container.decode(Int.self))
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let decoded = MapKeyValue.decodeNumeric(from: decoder, container)
+            if decoded != nil {
+                self = decoded!
+                return
+            }
+            let value = try container.decode(PklSwift.PklAny.self).value
+            switch value?.base {
+            case let decoded as String:
+                self = MapKeyValue.string(decoded)
+            default:
+                throw DecodingError.typeMismatch(
+                    MapKeyValue.self,
+                    .init(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Expected type MapKeyValue, but got \(String(describing: value))"
+                    )
+                )
+            }
+        }
+    }
+
+    public struct Module: PklRegisteredType, Decodable, Hashable, @unchecked Sendable {
+        public static let registeredIdentifier: String = "Ref"
+
+        public var res0: Reference<D>
+
+        public var res1: Reference<D>
+
+        public var res2: Reference<D>
+
+        public var res3: Reference<D>
+
+        public var res4: Reference<D>
+
+        public var res5: AnyHashable?
+
+        public init(
+            res0: Reference<D>,
+            res1: Reference<D>,
+            res2: Reference<D>,
+            res3: Reference<D>,
+            res4: Reference<D>,
+            res5: AnyHashable?
+        ) {
+            self.res0 = res0
+            self.res1 = res1
+            self.res2 = res2
+            self.res3 = res3
+            self.res4 = res4
+            self.res5 = res5
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let dec = try decoder.container(keyedBy: PklCodingKey.self)
+            let res0 = try dec.decode(Reference<D>.self, forKey: PklCodingKey(string: "res0"))
+            let res1 = try dec.decode(Reference<D>.self, forKey: PklCodingKey(string: "res1"))
+            let res2 = try dec.decode(Reference<D>.self, forKey: PklCodingKey(string: "res2"))
+            let res3 = try dec.decode(Reference<D>.self, forKey: PklCodingKey(string: "res3"))
+            let res4 = try dec.decode(Reference<D>.self, forKey: PklCodingKey(string: "res4"))
+            let res5 = try dec.decode(PklSwift.PklAny.self, forKey: PklCodingKey(string: "res5"))
+                .value
+            self = Module(res0: res0, res1: res1, res2: res2, res3: res3, res4: res4, res5: res5)
+        }
+    }
+
+    public struct D: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "Ref#D"
+
+        public init() {}
+    }
+
+    public struct A: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "Ref#A"
+
+        public var foo: Int
+
+        public var bar: [PklSwift.OptionalDictionaryKey<String>: Int]
+
+        public var baz: [MapKey: String]
+
+        public init(
+            foo: Int,
+            bar: [PklSwift.OptionalDictionaryKey<String>: Int],
+            baz: [MapKey: String]
+        ) {
+            self.foo = foo
+            self.bar = bar
+            self.baz = baz
+        }
+    }
+
+    public struct MapKey: PklRegisteredType, Decodable, Hashable, Sendable {
+        public static let registeredIdentifier: String = "Ref#MapKey"
+
+        public var key: MapKeyValue
+
+        public init(key: MapKeyValue) {
+            self.key = key
+        }
+    }
+
+    /// Load the Pkl module at the given source and evaluate it into `Ref.Module`.
+    ///
+    /// - Parameter source: The source of the Pkl module.
+    public static func loadFrom(source: ModuleSource) async throws -> Ref.Module {
+        try await PklSwift.withEvaluator { evaluator in
+            try await loadFrom(evaluator: evaluator, source: source)
+        }
+    }
+
+    /// Load the Pkl module at the given source and evaluate it with the given evaluator into
+    /// `Ref.Module`.
+    ///
+    /// - Parameter evaluator: The evaluator to use for evaluation.
+    /// - Parameter source: The module to evaluate.
+    public static func loadFrom(
+        evaluator: PklSwift.Evaluator,
+        source: PklSwift.ModuleSource
+    ) async throws -> Ref.Module {
+        try await evaluator.evaluateModule(source: source, as: Module.self)
+    }
+}

--- a/Tests/PklSwiftTests/Fixtures/Ref.pkl
+++ b/Tests/PklSwiftTests/Fixtures/Ref.pkl
@@ -1,0 +1,25 @@
+module Ref
+
+import "pkl:ref"
+
+class D extends ref.Domain
+local d: D = new {}
+
+class A {
+  foo: Int
+  bar: Mapping<String?, Int>
+  baz: Mapping<MapKey, String>
+}
+
+class MapKey {
+  key: MapKeyValue
+}
+
+typealias MapKeyValue = String | Int
+
+res0: ref.Reference<D, A> = ref.Reference(d, A, "hi")
+res1: ref.Reference<D, Int> = res0.foo
+res2: ref.Reference<D, Int> = res0.bar["hi"]
+res3: ref.Reference<D, Int> = res0.bar[null]
+res4: ref.Reference<D, String> = res0.baz[new MapKey { key = "foo" }]
+res5: Any = res0.baz[new MapKey { key = 1 }]

--- a/Tests/PklSwiftTests/FixturesTest.swift
+++ b/Tests/PklSwiftTests/FixturesTest.swift
@@ -264,5 +264,38 @@ class FixturesTest: XCTestCase {
             numbers4: .int(Int.max)
         ))
     }
+
+    func testRef() async throws {
+        let version = try await SemanticVersion(EvaluatorManager().getVersion())!
+        debug("\(version < pklVersion0_32)")
+        if version < pklVersion0_32 {
+            throw XCTSkip("ref.Reference is not available")
+        }
+
+        let result = try await Ref.loadFrom(
+            evaluator: self.evaluator,
+            source: .path("\(#filePath)/../Fixtures/Ref.pkl")
+        )
+        XCTAssertEqual(result, .init(
+            res0: .init(domain: Ref.D(), data: "hi", path: []),
+            res1: .init(domain: Ref.D(), data: "hi", path: [.property("foo")]),
+            res2: .init(domain: Ref.D(), data: "hi", path: [
+                .property("bar"),
+                .subscriptKey("hi"),
+            ]),
+            res3: .init(domain: Ref.D(), data: "hi", path: [
+                .property("bar"),
+                .subscriptKey(nil),
+            ]),
+            res4: .init(domain: Ref.D(), data: "hi", path: [
+                .property("baz"),
+                .subscriptKey(Ref.MapKey(key: .string("foo"))),
+            ]),
+            res5: Reference<AnyHashable?>(domain: Ref.D(), data: "hi", path: [
+                .property("baz"),
+                .subscriptKey(Ref.MapKey(key: .int(1))),
+            ]),
+        ))
+    }
 }
 #endif

--- a/codegen/src/gen.pkl
+++ b/codegen/src/gen.pkl
@@ -14,7 +14,7 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-@ModuleInfo { minPklVersion = "0.31.0" }
+@ModuleInfo { minPklVersion = "0.32.0" }
 module pkl.swift.gen
 
 extends "pkl:Command"

--- a/codegen/src/internal/Type.pkl
+++ b/codegen/src/internal/Type.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ class Dictionary extends Type {
     let (sep = if (inner.second.length > innerKey.second.length) inner.second else innerKey.second)
       Pair(
         "\(pklTypeName)\(sep)\(inner.first)\(sep)\(innerKey.first)",
-        sep + "_"
+        sep + "_",
       )
 }
 
@@ -122,7 +122,7 @@ class Array extends Type {
     let (sep = inner.second)
       Pair(
         "\(pklTypeName)\(sep)\(inner.first)",
-        sep + "_"
+        sep + "_",
       )
 }
 
@@ -151,7 +151,7 @@ class Optional extends Type {
     let (sep = inner.second)
       Pair(
         "Optional\(sep)\(inner.first)",
-        sep + "_"
+        sep + "_",
       )
 }
 
@@ -173,7 +173,7 @@ class Tuple extends Type {
     let (sep = inners.firstOrNull?.second ?? "_")
       Pair(
         "Tuple\(sep)\(inners.join(sep))",
-        sep + "_"
+        sep + "_",
       )
 }
 
@@ -235,6 +235,6 @@ class Declared extends Type {
   function renderEnumCaseName(withinNamespace: String?): Pair<String, String> =
     Pair(
       utils.normalizeName(render(withinNamespace).replaceFirst(Regex("^any "), "")),
-      ""
+      "",
     )
 }

--- a/codegen/src/internal/gatherer.pkl
+++ b/codegen/src/internal/gatherer.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import "typegen.pkl"
 /// This omits core built-in types.
 function gatherTypeDeclarations(
   decl: reflect.TypeDeclaration,
-  seen: List<reflect.TypeDeclaration>
+  seen: List<reflect.TypeDeclaration>,
 ): List<reflect.TypeDeclaration> =
   if (seen.contains(decl))
     seen
@@ -64,7 +64,7 @@ function isBuiltinClass(clazz: reflect.Class): Boolean =
 function gatherTypeDeclarationsFromType(
   type: reflect.Type,
   enclosingDeclaration: reflect.TypeDeclaration,
-  seen: List<reflect.TypeDeclaration>
+  seen: List<reflect.TypeDeclaration>,
 ): List<reflect.TypeDeclaration> =
   if (type is reflect.DeclaredType)
     let (referent = type.referent)

--- a/codegen/src/internal/typegen.pkl
+++ b/codegen/src/internal/typegen.pkl
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 @Unlisted
 module pkl.swift.internal.typegen
 
+import "pkl:ref"
 import "pkl:reflect"
 
 import "SwiftMapping.pkl"
@@ -26,7 +27,7 @@ import "Type.pkl"
 function generateType(
   type: reflect.Type,
   enclosing: reflect.TypeDeclaration,
-  seenMappings: List<SwiftMapping>
+  seenMappings: List<SwiftMapping>,
 ): Type =
   if (type is reflect.DeclaredType)
     generateDeclaredType(type, enclosing, seenMappings)
@@ -65,7 +66,7 @@ function generateUnionType(type: reflect.UnionType, seenMappings: List<SwiftMapp
 function generateDeclaredType(
   type: reflect.DeclaredType,
   enclosing: reflect.TypeDeclaration,
-  seenMappings: List<SwiftMapping>
+  seenMappings: List<SwiftMapping>,
 ): Type =
   let (referent = type.referent)
   let (reflectee = type.referent.reflectee)
@@ -133,11 +134,15 @@ mappedTypes: Mapping<Class | TypeAlias, Type> = new {
       typeName = "UInt8"
     }
   }
+  [ref.Access] = new Type.Declared {
+    swiftModuleName = "PklSwift"
+    typeName = "ReferenceAccess"
+  }
 }
 
 mappedHigherOrderTypes: Mapping<
   Class | TypeAlias,
-  (reflect.DeclaredType, reflect.TypeDeclaration, List<SwiftMapping>) -> Type
+  (reflect.DeclaredType, reflect.TypeDeclaration, List<SwiftMapping>) -> Type,
 > = new {
   [List] = this[Listing]
   [Listing] = (type, enclosing, seenMappings) ->
@@ -175,7 +180,19 @@ mappedHigherOrderTypes: Mapping<
         if (typeArg == null)
           anyType
         else
-          generateType(typeArg, enclosing, seenMappings)
+          generateType(typeArg, enclosing, seenMappings),
+      )
+  }
+  [ref.Reference] = (type, enclosing, seenMappings) -> new Type.Declared {
+    local typeArg = type.typeArguments.getOrNull(0)
+    swiftModuleName = "PklSwift"
+    typeName = "Reference"
+    typeArguments =
+      List(
+        if (typeArg == null)
+          anyType
+        else
+          generateType(typeArg, enclosing, seenMappings),
       )
   }
 }

--- a/codegen/src/internal/utils.pkl
+++ b/codegen/src/internal/utils.pkl
@@ -113,7 +113,7 @@ keywords: List<String> =
     "true",
     "try",
     "Type",
-    "_"
+    "_",
   )
 
 function renderDocComment(docComment: String, indent: String) =

--- a/codegen/src/tests/utils.pkl
+++ b/codegen/src/tests/utils.pkl
@@ -49,7 +49,7 @@ facts {
       my multiline
 
       string
-      """
+      """,
     )
       == #"""
       """
@@ -63,7 +63,7 @@ facts {
       multiline string
 
       with `backticks`
-      """
+      """,
     )
       == #"""
       """


### PR DESCRIPTION
Requires https://github.com/apple/pkl/pull/1354 and Pkl 0.32 release

Also: move to the latest grammar version for Pkl formatting. This requires dropping support for codegen on Pkl < 0.30. We've already done that, so this isn't a breaking change.