### PR TITLE
Add support for resolved evaluator settings

### DIFF
--- a/Sources/PklSwift/Decoder/PklTypedDecodingContainer.swift
+++ b/Sources/PklSwift/Decoder/PklTypedDecodingContainer.swift
@@ -116,9 +116,7 @@ extension _PklDecoder {
 
         func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
             guard let propertyValue = properties[key.stringValue] else {
-                throw DecodingError.dataCorruptedError(
-                    forKey: key, in: self, debugDescription: "Missing key \(key)"
-                )
+                throw DecodingError.keyNotFound(key, .init(codingPath: self.codingPath, debugDescription: "Missing key \(key)"))
             }
 
             // special case for polymorphic types
@@ -133,9 +131,7 @@ extension _PklDecoder {
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws
             -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
             guard let propertyValue = properties[key.stringValue] else {
-                throw DecodingError.dataCorruptedError(
-                    forKey: key, in: self, debugDescription: "Missing key \(key)"
-                )
+                throw DecodingError.keyNotFound(key, .init(codingPath: self.codingPath, debugDescription: "Missing key \(key)"))
             }
             var nestedCodingPath = self.codingPath
             nestedCodingPath.append(key)

--- a/Sources/PklSwift/EvaluatorManager.swift
+++ b/Sources/PklSwift/EvaluatorManager.swift
@@ -348,7 +348,13 @@ public actor EvaluatorManager {
                 source: .url(projectBaseURI.appendingPathComponent("PklProject")),
                 asType: Project.self
             )
-            return try await self.newEvaluator(options: options.withProject(project))
+            let version = try SemanticVersion(getVersion())
+            let resolvedOptions = if version! < pklVersion0_32 {
+                options.withProjectLegacy(project)
+            } else {
+                options.withProject(project)
+            }
+            return try await self.newEvaluator(options: resolvedOptions)
         }
     }
 

--- a/Sources/PklSwift/EvaluatorOptions.swift
+++ b/Sources/PklSwift/EvaluatorOptions.swift
@@ -327,6 +327,14 @@ extension EvaluatorOptions {
 
     /// Builds options with evaluator settings as well as dependencies from the input project.
     public func withProject(_ project: Project) -> EvaluatorOptions {
+        self.withProjectEvaluatorSettings(project.resolvedEvaluatorSettings)
+            .withProjectDependencies(project)
+    }
+
+    /// Behaves like `withProject`, except applies the _unresolved_ evaluator settings.
+    ///
+    /// If using Pkl 0.32 or newer, prefer using `withProject`.
+    public func withProjectLegacy(_ project: Project) -> EvaluatorOptions {
         self.withProjectEvaluatorSettings(project.evaluatorSettings)
             .withProjectDependencies(project)
     }

--- a/Sources/PklSwift/PklEvaluatorSettings.swift
+++ b/Sources/PklSwift/PklEvaluatorSettings.swift
@@ -16,6 +16,38 @@
 
 /// The Swift representation of standard library module `pkl.EvaluatorSettings`.
 public struct PklEvaluatorSettings: Decodable, Hashable, Sendable {
+    public init(
+        externalProperties: [String: String]? = nil,
+        env: [String: String]? = nil,
+        allowedModules: [String]? = nil,
+        allowedResources: [String]? = nil,
+        noCache: Bool? = nil,
+        modulePath: [String]? = nil,
+        timeout: Duration? = nil,
+        moduleCacheDir: String? = nil,
+        rootDir: String? = nil,
+        http: Http? = nil,
+        externalModuleReaders: [String: ExternalReader]? = nil,
+        externalResourceReaders: [String: ExternalReader]? = nil,
+        color: PklEvaluatorSettingsColor? = nil,
+        traceMode: TraceMode? = nil
+    ) {
+        self.externalProperties = externalProperties
+        self.env = env
+        self.allowedModules = allowedModules
+        self.allowedResources = allowedResources
+        self.noCache = noCache
+        self.modulePath = modulePath
+        self.timeout = timeout
+        self.moduleCacheDir = moduleCacheDir
+        self.rootDir = rootDir
+        self.http = http
+        self.externalModuleReaders = externalModuleReaders
+        self.externalResourceReaders = externalResourceReaders
+        self.color = color
+        self.traceMode = traceMode
+    }
+
     let externalProperties: [String: String]?
     let env: [String: String]?
     let allowedModules: [String]?

--- a/Sources/PklSwift/Project.swift
+++ b/Sources/PklSwift/Project.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+// Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,13 +22,16 @@ public struct Project: PklRegisteredType, Hashable, DependencyDeclaredInProjectF
 
     let evaluatorSettings: PklEvaluatorSettings
 
+    /// Added in Pkl 0.32
+    let resolvedEvaluatorSettings: PklEvaluatorSettings
+
     let projectFileUri: String
 
     let tests: [String]
 
     let dependencies: [String: any DependencyDeclaredInProjectFile]
 
-    public static func ==(lhs: Project, rhs: Project) -> Bool {
+    public static func == (lhs: Project, rhs: Project) -> Bool {
         lhs.hashValue == rhs.hashValue
     }
 
@@ -46,18 +49,51 @@ public struct Project: PklRegisteredType, Hashable, DependencyDeclaredInProjectF
 
 public protocol DependencyDeclaredInProjectFile: Hashable, Decodable, Equatable, Sendable {}
 
+private let emptyEvaluatorSettings: PklEvaluatorSettings = .init(
+    externalProperties: nil,
+    env: nil,
+    allowedModules: nil,
+    allowedResources: nil,
+    noCache: nil,
+    modulePath: nil,
+    timeout: nil,
+    moduleCacheDir: nil,
+    rootDir: nil,
+    http: nil,
+    externalModuleReaders: nil,
+    externalResourceReaders: nil,
+    color: nil,
+    traceMode: nil
+)
+
 extension Project: Decodable {
     public init(from decoder: Decoder) throws {
         let dec = try decoder.container(keyedBy: PklCodingKey.self)
         let package = try dec.decode(Package?.self, forKey: PklCodingKey(stringValue: "package")!)
-        let evaluatorSettings = try dec.decode(PklEvaluatorSettings.self, forKey: PklCodingKey(stringValue: "evaluatorSettings")!)
-        let projectFileUri = try dec.decode(String.self, forKey: PklCodingKey(stringValue: "projectFileUri")!)
+        let evaluatorSettings = try dec.decode(
+            PklEvaluatorSettings.self, forKey: PklCodingKey(stringValue: "evaluatorSettings")!
+        )
+        var resolvedEvaluatorSettings: PklEvaluatorSettings
+        do {
+            resolvedEvaluatorSettings = try dec.decode(
+                PklEvaluatorSettings.self,
+                forKey: PklCodingKey(stringValue: "resolvedEvaluatorSettings")!
+            )
+        } catch DecodingError.keyNotFound {
+            resolvedEvaluatorSettings = emptyEvaluatorSettings
+        }
+        let projectFileUri = try dec.decode(
+            String.self, forKey: PklCodingKey(stringValue: "projectFileUri")!
+        )
         let tests = try dec.decode([String].self, forKey: PklCodingKey(stringValue: "tests")!)
-        let dependencies = try dec.decode([String: PklAny].self, forKey: PklCodingKey(stringValue: "dependencies")!)
-            .mapValues { $0.value as! any DependencyDeclaredInProjectFile }
+        let dependencies = try dec.decode(
+            [String: PklAny].self, forKey: PklCodingKey(stringValue: "dependencies")!
+        )
+        .mapValues { $0.value as! any DependencyDeclaredInProjectFile }
         self = .init(
             package: package,
             evaluatorSettings: evaluatorSettings,
+            resolvedEvaluatorSettings: resolvedEvaluatorSettings,
             projectFileUri: projectFileUri,
             tests: tests,
             dependencies: dependencies
@@ -67,7 +103,8 @@ extension Project: Decodable {
 
 extension Project {
     /// The Swift representation of `pkl.Project#RemoteDependency`
-    public struct RemoteDependency: PklRegisteredType, DependencyDeclaredInProjectFile, Decodable, Hashable {
+    public struct RemoteDependency: PklRegisteredType, DependencyDeclaredInProjectFile, Decodable,
+        Hashable {
         public static let registeredIdentifier: String = "pkl.Project#RemoteDependency"
 
         let uri: String

--- a/Sources/PklSwift/Project.swift
+++ b/Sources/PklSwift/Project.swift
@@ -49,22 +49,7 @@ public struct Project: PklRegisteredType, Hashable, DependencyDeclaredInProjectF
 
 public protocol DependencyDeclaredInProjectFile: Hashable, Decodable, Equatable, Sendable {}
 
-private let emptyEvaluatorSettings: PklEvaluatorSettings = .init(
-    externalProperties: nil,
-    env: nil,
-    allowedModules: nil,
-    allowedResources: nil,
-    noCache: nil,
-    modulePath: nil,
-    timeout: nil,
-    moduleCacheDir: nil,
-    rootDir: nil,
-    http: nil,
-    externalModuleReaders: nil,
-    externalResourceReaders: nil,
-    color: nil,
-    traceMode: nil
-)
+private let emptyEvaluatorSettings: PklEvaluatorSettings = .init()
 
 extension Project: Decodable {
     public init(from decoder: Decoder) throws {

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -513,9 +513,9 @@ final class PklSwiftTests: XCTestCase {
                 rootDir = "."
             }
             """.write(to: project1Dir.appendingPathComponent("PklProject"), atomically: true, encoding: .utf8)
-            try await manager.withProjectEvaluator(projectBaseURI: project1Dir) { evalutor in
+            try await manager.withProjectEvaluator(projectBaseURI: project1Dir) { evaluator in
                 do {
-                    _ = try await evalutor.evaluateOutputText(source: .path("/foo.pkl"))
+                    _ = try await evaluator.evaluateOutputText(source: .path("/foo.pkl"))
                     XCTFail("expected evaluation to throw")
                 } catch {
                     XCTAssertTrue(error is PklError)

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -516,6 +516,7 @@ final class PklSwiftTests: XCTestCase {
             try await manager.withProjectEvaluator(projectBaseURI: project1Dir) { evalutor in
                 do {
                     _ = try await evalutor.evaluateOutputText(source: .path("/foo.pkl"))
+                    XCTFail("expected evaluation to throw")
                 } catch {
                     XCTAssertTrue(error is PklError)
                     let error = error as! PklError

--- a/Tests/PklSwiftTests/EvaluatorTest.swift
+++ b/Tests/PklSwiftTests/EvaluatorTest.swift
@@ -496,5 +496,33 @@ final class PklSwiftTests: XCTestCase {
 //            """, output)
 //        }
 //    }
+
+    func testWithProjectEvaluatorConfiguredSettings() async throws {
+        try await withEvaluatorManager { manager in
+            let version = try await SemanticVersion(manager.getVersion())!
+            if version < pklVersion0_32 {
+                throw XCTSkip("Resolved evaluator settings require Pkl 0.32 or later.")
+            }
+
+            let project1Dir = try (tempDir()).appendingPathComponent("project1")
+            try FileManager.default.createDirectory(at: project1Dir, withIntermediateDirectories: true)
+            try """
+            amends "pkl:Project"
+
+            evaluatorSettings {
+                rootDir = "."
+            }
+            """.write(to: project1Dir.appendingPathComponent("PklProject"), atomically: true, encoding: .utf8)
+            try await manager.withProjectEvaluator(projectBaseURI: project1Dir) { evalutor in
+                do {
+                    _ = try await evalutor.evaluateOutputText(source: .path("/foo.pkl"))
+                } catch {
+                    XCTAssertTrue(error is PklError)
+                    let error = error as! PklError
+                    XCTAssertTrue(error.message.contains("Refusing to load module `file:///foo.pkl`"))
+                }
+            }
+        }
+    }
 }
 #endif

--- a/Tests/PklSwiftTests/ProjectTest.swift
+++ b/Tests/PklSwiftTests/ProjectTest.swift
@@ -303,8 +303,6 @@ class ProjectTest: XCTestCase {
         }
         let tempDir = try tempDir()
         let pklProjectFile = tempDir.appendingPathComponent("PklProject")
-        // let subDir = tempDir.appendingPathComponent("subdir")
-        // try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
 
         try #"""
         @ModuleInfo { minPklVersion = "0.25.0" }
@@ -319,7 +317,11 @@ class ProjectTest: XCTestCase {
                 source: .url(pklProjectFile),
                 asType: Project.self
             )
-            XCTAssertEqual(project.resolvedEvaluatorSettings.rootDir, "\(tempDir.path(percentEncoded: false).dropLast())")
+            var expectedRootDir = tempDir.path(percentEncoded: false)
+            if expectedRootDir.hasSuffix("/") {
+                expectedRootDir.removeLast()
+            }
+            XCTAssertEqual(project.resolvedEvaluatorSettings.rootDir, expectedRootDir)
         }
     }
 }

--- a/Tests/PklSwiftTests/ProjectTest.swift
+++ b/Tests/PklSwiftTests/ProjectTest.swift
@@ -315,12 +315,11 @@ class ProjectTest: XCTestCase {
         }
         """#.write(to: pklProjectFile, atomically: true, encoding: .utf8)
         try await withEvaluator { evaluator in
-
             let project = try await evaluator.evaluateOutputValue(
                 source: .url(pklProjectFile),
                 asType: Project.self
             )
-            XCTAssertEqual(project.resolvedEvaluatorSettings.rootDir, "\(tempDir.path().dropLast())")
+            XCTAssertEqual(project.resolvedEvaluatorSettings.rootDir, "\(tempDir.path(percentEncoded: false).dropLast())")
         }
     }
 }

--- a/Tests/PklSwiftTests/ProjectTest.swift
+++ b/Tests/PklSwiftTests/ProjectTest.swift
@@ -248,6 +248,22 @@ class ProjectTest: XCTestCase {
                         color: nil,
                         traceMode: nil
                     ),
+                    resolvedEvaluatorSettings: .init(
+                        externalProperties: nil,
+                        env: nil,
+                        allowedModules: nil,
+                        allowedResources: nil,
+                        noCache: nil,
+                        modulePath: nil,
+                        timeout: nil,
+                        moduleCacheDir: nil,
+                        rootDir: nil,
+                        http: nil,
+                        externalModuleReaders: nil,
+                        externalResourceReaders: nil,
+                        color: nil,
+                        traceMode: nil
+                    ),
                     projectFileUri: "\(otherProjectFile)",
                     tests: [],
                     dependencies: [:]
@@ -277,6 +293,34 @@ class ProjectTest: XCTestCase {
             XCTAssertEqual(opts.externalModuleReaders, externalModuleReadersExpectation)
             XCTAssertEqual(opts.externalResourceReaders, externalResourceReadersExpectation)
             XCTAssertEqual(opts.traceMode, traceMode)
+        }
+    }
+
+    func testLoadResolvedEvaluatorSettings() async throws {
+        let version = try await SemanticVersion(EvaluatorManager().getVersion())!
+        if version < pklVersion0_32 {
+            throw XCTSkip("resolvedEvaluatorSettings not available")
+        }
+        let tempDir = try tempDir()
+        let pklProjectFile = tempDir.appendingPathComponent("PklProject")
+        // let subDir = tempDir.appendingPathComponent("subdir")
+        // try FileManager.default.createDirectory(at: subDir, withIntermediateDirectories: true)
+
+        try #"""
+        @ModuleInfo { minPklVersion = "0.25.0" }
+        amends "pkl:Project"
+
+        evaluatorSettings {
+          rootDir = "."
+        }
+        """#.write(to: pklProjectFile, atomically: true, encoding: .utf8)
+        try await withEvaluator { evaluator in
+
+            let project = try await evaluator.evaluateOutputValue(
+                source: .url(pklProjectFile),
+                asType: Project.self
+            )
+            XCTAssertEqual(project.resolvedEvaluatorSettings.rootDir, "\(tempDir.path().dropLast())")
         }
     }
 }


### PR DESCRIPTION
* Breaking change: `withProject` uses _resolved_ evaluator settings
* `withProjectEvaluator` and derived methods load using either resolved settings or unresolved settings based on Pkl version
* Treat `resolvedEvaluatorSettings` 
* Fix: use `DecodingError.keyNotFound` error across the board when coding key is missing